### PR TITLE
fix(export): PDF download saved a 23-byte error file for larger journals

### DIFF
--- a/src/pages/api/settings/html-to-image.ts
+++ b/src/pages/api/settings/html-to-image.ts
@@ -2,6 +2,17 @@ import { api } from "src/blitz-server"
 import puppeteer from "puppeteer"
 // https://github.com/puppeteer/puppeteer/blob/v14.1.0/docs/api.md#pagepdfoptions
 
+export const config = {
+  api: {
+    // the serialized #pdf markup (all dreams + inlined base64 images) easily exceeds
+    // Next's default 1mb body limit — which used to truncate downloads to a 23-byte
+    // "Body exceeded 1mb limit" response saved as the PDF
+    bodyParser: {
+      sizeLimit: "10mb",
+    },
+  },
+}
+
 async function htmlToImage(html = "", css = "") {
   const browser = await puppeteer.launch({
     headless: true,
@@ -31,9 +42,11 @@ async function htmlToImage(html = "", css = "") {
 }
 
 export default api(async (req, res, ctx) => {
-  if (ctx.session.userId) {
-    const { html, css } = JSON.parse(req.body)
-    const pdf = await htmlToImage(html, css)
-    res.send(pdf)
+  if (!ctx.session.userId) {
+    res.status(401).end()
+    return
   }
+  const { html, css } = JSON.parse(req.body)
+  const pdf = await htmlToImage(html, css)
+  res.send(pdf)
 })

--- a/src/settings/components/ExportDreams/index.tsx
+++ b/src/settings/components/ExportDreams/index.tsx
@@ -54,23 +54,26 @@ export const ExportDreams = () => {
     const element = document.getElementById("pdf")
     if (element) {
       const csrf = getAntiCSRFToken()
-      await fetch("/api/settings/html-to-image", {
+      const res = await fetch("/api/settings/html-to-image", {
         method: "POST",
         headers: {
           "anti-csrf": csrf,
         },
         body: JSON.stringify({ html: element.innerHTML }),
       })
-        .then((res) => {
-          return res.arrayBuffer()
-        })
-        .then((data) => {
-          const blob = new Blob([data], { type: "application/pdf" })
-          const link = document.createElement("a")
-          link.href = window.URL.createObjectURL(blob)
-          link.download = "dreamjournal.pdf"
-          link.click()
-        })
+      if (!res.ok) {
+        // e.g. a 413 when the journal outgrows the API body limit — don't save the
+        // error message as a broken "PDF"
+        console.error("PDF generation failed:", res.status, await res.text())
+        window.alert("Sorry, the PDF could not be generated. Please try again.")
+        return
+      }
+      const data = await res.arrayBuffer()
+      const blob = new Blob([data], { type: "application/pdf" })
+      const link = document.createElement("a")
+      link.href = window.URL.createObjectURL(blob)
+      link.download = "dreamjournal.pdf"
+      link.click()
     }
   }
 


### PR DESCRIPTION
## Summary

Clicking **Download** in the dreamjournal.pdf dialog produced an empty ~23-byte file for larger journals, while the preview looked fine.

**Root cause**: the preview renders client-side, but the download POSTs the serialized `#pdf` markup (every dream + the inlined base64 logo/title images) to `/api/settings/html-to-image`. Once a journal outgrows **Next's default 1 MB API body limit**, the route replies `413` with the plain-text body `Body exceeded 1mb limit` — exactly 23 bytes — and the client saved that error text as the PDF because it never checked `res.ok`.

**Fix**:
- `html-to-image.ts`: `bodyParser.sizeLimit: "10mb"` via the standard route `config` (same pattern as the S3 routes); logged-out requests now get a proper `401` instead of a hanging response
- `ExportDreams`: `download()` checks `res.ok` — on failure it logs the status + body and shows an alert instead of silently saving a broken file

## Test plan

- reproduced the bug: >1 MB payload → 413 / 23 bytes saved as "PDF" ✅
- after the fix: a realistic 1.67 MB journal payload (~2,000 dreams) returns a valid 2.4 MB PDF; small journals unaffected ✅
- `npm run lint`, `npm run type:check`, `npm test` — ✅

## Deploy note

nginx's `client_max_body_size` (default 1m) must also allow larger request bodies — the 3 MB picture uploads suggest it's already raised, but worth confirming it's ≥ 10m before relying on this in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)