### PR TITLE
feat(dx): Docker-only local dev route + MinIO S3 mock for symbol uploads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,21 @@ AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_REGION=
 S3_BUCKET=
+# public URL prefix the browser loads symbol images from, e.g. https://<bucket>.s3.<region>.amazonaws.com
 NEXT_PUBLIC_S3_BUCKET=
+
+## Local S3 mock (MinIO via `docker compose -f docker-compose.local.yml up -d`):
+## uncomment ONLY the six KEY=value lines below, INSTEAD of the AWS values above,
+## to test uploads without AWS. S3_ENDPOINT switches the S3 client to the mock —
+## leave it unset in production! Keep these `##` description lines commented:
+## this file is also parsed by `docker compose` (env_file), which accepts nothing
+## but KEY=value pairs and full-line comments.
+# S3_ENDPOINT=http://localhost:9000
+# AWS_ACCESS_KEY_ID=test
+# AWS_SECRET_ACCESS_KEY=test1234
+# AWS_REGION=us-east-1
+# S3_BUCKET=dreamingsheep-local
+# NEXT_PUBLIC_S3_BUCKET=http://localhost:9000/dreamingsheep-local
 
 # Gmail OAuth2 (for sending emails, required for production, OAuth way of authentication via https://developers.google.com/oauthplayground/)
 GMAIL_USER_MAIL=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,10 @@ test/e2e/          # Puppeteer end-to-end tests
 - `npm test` — unit tests (Vitest); fast, no DB needed
 - `npm run test:e2e` — puppeteer end-to-end tests; needs a running dev server
   and a seeded DB (details in [README.md](README.md))
+- **Symbol image uploads** don't need real AWS credentials: start the local S3
+  mock with `docker compose -f docker-compose.local.yml up -d` and set the
+  "Local S3 mock" block from [.env.example](.env.example) in your `.env.local`
+  (full walkthrough in [README.md](README.md#-local-dev-services-in-docker-s3-mock--postgresql))
 - CI runs lint, type-check and unit tests on every PR
 - Philosophy (see [#2](https://github.com/talpitoo/dreamingsheep/issues/2)):
   test what actually breaks — edge cases over coverage percentages

--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 
 # 🐏 _dreamingsheep_
 
-## Getting Started (on your local machine)
+Two ways to run it locally — pick one route and read only that section:
+
+- 💻 **natively** — Node.js + PostgreSQL on your machine; the everyday development setup (hot reload via `blitz dev`)
+- 🐋 **everything in Docker** — the only prerequisite is Docker; app, database and S3 mock all run in containers
+
+Either way, the 🪣 **local dev services** section covers running just the S3 mock
+(and/or PostgreSQL) in Docker — handy companions for the native route.
+
+## 💻 Getting Started natively (Node.js + PostgreSQL on your machine)
 
 1. Install Node.js (e.g. https://www.digitalocean.com/community/tutorials/how-to-install-node-js-on-ubuntu-20-04).
 2. Install PostgreSQL (e.g. https://www.digitalocean.com/community/tutorials/how-to-install-postgresql-on-ubuntu-20-04-quickstart).
@@ -21,7 +29,140 @@
 Run your app in the development mode.
 
 14. `blitz dev`
-15. Open [localhost:3000](http://localhost:3000) with your browser to see the result.
+15. Open [localhost:3000](http://localhost:3000) with your browser to see the result — log in with the seeded demo user `zhuangzi@dreamingsheep.net` / `zhuangzi`.
+16. (optional) Symbol image uploads need an S3 bucket — either real AWS credentials in `.env.local`, or the 🪣 local S3 mock below (no AWS account needed).
+17. (optional) If you want to test emails 1) sign up with a real email (you should receive a welcome email with a confirmation code), then sign out and initiate the forgot password flow (you should receive a forgot password email with a token). Requires the Gmail OAuth2 values in `.env.local`.
+18. For contribution guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md). For the project roadmap, see [ROADMAP.md](ROADMAP.md).
+
+## 🐋 Getting Started with Docker (the only prerequisite is Docker)
+
+Everything — app, PostgreSQL and the S3 mock — runs in containers via
+[docker-compose.production.yml](docker-compose.production.yml) +
+[docker-compose.local.yml](docker-compose.local.yml). No Node.js, PostgreSQL or
+AWS account needed on your machine. The compose setup mirrors a production-style
+deployment, but note that **production does not actually run Docker** (it's a plain
+EC2 box) — the compose file is kept as a future deployment option and as the
+quickest way to try dreamingsheep locally.
+
+The app container uses `network_mode: host`, so it reaches everything under
+`localhost` — your `.env.local` values work unchanged in and out of Docker.
+
+1. Install Docker (with the Compose v2 plugin — the commands below use `docker compose`, not the old `docker-compose`).
+2. (optional) Run `sudo usermod -aG docker <username>` (then log out, log in) or run all docker commands with `sudo`.
+3. Create your env file — for the all-Docker route this minimal recipe is enough:
+
+```sh
+cp .env.example .env.local
+```
+
+&nbsp;&nbsp;&nbsp;&nbsp;then edit `.env.local` and set only:
+
+```sh
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/dreamingsheep
+SESSION_SECRET_KEY=<paste the output of: openssl rand -hex 16>
+JWT_SECRET=<paste the output of: openssl rand -hex 64>
+# ...and uncomment the six KEY=value lines of the "Local S3 mock" block, so symbol
+# image uploads work out of the box (keep the ## description lines commented —
+# docker compose parses this file strictly)
+```
+
+&nbsp;&nbsp;&nbsp;&nbsp;Everything else (AWS, Gmail, reCAPTCHA) can stay empty locally — sign in with the seeded demo user instead of signing up.
+&nbsp;&nbsp;&nbsp;&nbsp;⚠️ If you use a different DB password: the compose PostgreSQL initializes from `POSTGRES_PASSWORD` (default `postgres`), and the password is baked into the volume on **first initialization only** — changing it later requires `docker volume rm volume-postgres-dreamingsheep` (wipes the DB!).
+
+4. **Free up port 5432** — the compose PostgreSQL maps it, and with `network_mode: host` the app connects to whatever answers on `localhost:5432`. If a host PostgreSQL keeps running, the dockerized app will silently talk to _it_ instead of the container:
+
+```sh
+sudo lsof -i :5432               # who owns the port?
+sudo systemctl stop postgresql   # stop the host PostgreSQL for the Docker session
+# later: sudo systemctl start postgresql
+```
+
+5. Build the app image (first time and after code or `NEXT_PUBLIC_*` changes — takes a few minutes). Two caveats: the build **copies `.env.local` into the image** and `NEXT_PUBLIC_*` values are inlined into the JS bundle at build time — so set the S3 mock block _before_ building, and never push the image to a registry (it contains your secrets):
+
+```sh
+docker compose -f docker-compose.production.yml build
+```
+
+6. Start the full stack (app + PostgreSQL + S3 mock), then migrate + seed the fresh database (first time only):
+
+```sh
+docker compose -f docker-compose.production.yml -f docker-compose.local.yml up -d
+
+docker exec -it docker-dreamingsheep bash
+blitz prisma migrate deploy   # applies the committed migrations (non-interactive)
+blitz db seed                 # demo users (zhuangzi/zhuangzi) + symbols + dreams
+exit
+```
+
+7. Open [localhost:3000](http://localhost:3000) and you should see the dreamingsheep landing page. Log in with the seeded demo user `zhuangzi@dreamingsheep.net` / `zhuangzi`.
+8. Try the symbol image uploads: Symbols page → **New symbol** → add a picture — upload, preview, quota and delete all run against the S3 mock. Browse the bucket at [localhost:9001](http://localhost:9001) (login `test` / `test1234`).
+9. (optional) `docker compose -f docker-compose.production.yml -f docker-compose.local.yml down` stops and removes the containers (the DB + S3 volumes survive; add `-v` to wipe them).
+10. (optional) All the docker images will require ~12GB of space (`docker images`):
+
+```
+REPOSITORY                  TAG      SIZE
+dreamingsheep-blitzjs-app   latest   11GB
+postgres                    13.4     533MB
+minio/minio                 latest   241MB   (S3 mock)
+minio/mc                    latest   117MB   (S3 mock init)
+```
+
+11. (optional) Other useful docker commands:
+
+```sh
+docker ps
+docker compose -f docker-compose.production.yml ps
+docker images
+docker rmi <id>
+docker logs docker-dreamingsheep
+docker logs docker-postgres-dreamingsheep
+docker exec -it docker-postgres-dreamingsheep psql -U postgres dreamingsheep   # poke the DB directly
+docker system prune -a
+docker volume ls
+docker volume rm volume-postgres-dreamingsheep   # wipe the dockerized DB (re-migrate + re-seed after)
+docker compose -f docker-compose.production.yml down --rmi all
+```
+
+## 🪣 Local dev services in Docker (S3 mock + PostgreSQL)
+
+Companions for the 💻 native route: run only the services in Docker while the app
+runs on your machine with `blitz dev`. (The 🐋 all-Docker route above already
+includes them.)
+
+**S3 mock** — symbol image uploads without an AWS account (issue
+[#13](https://github.com/talpitoo/dreamingsheep/issues/13)).
+[docker-compose.local.yml](docker-compose.local.yml) ships a **MinIO** mock
+(LocalStack's free Docker images were discontinued in March 2026) plus a one-shot
+init container that creates the `dreamingsheep-local` bucket and opens it for
+anonymous downloads (the browser loads symbol images directly from the bucket URL).
+
+1. Start it:
+
+```sh
+docker compose -f docker-compose.local.yml up -d
+```
+
+2. Point the app at it — uncomment the six `KEY=value` lines of the "Local S3 mock" block in `.env.local` (see [.env.example](.env.example)):
+
+```sh
+S3_ENDPOINT=http://localhost:9000
+AWS_ACCESS_KEY_ID=test
+AWS_SECRET_ACCESS_KEY=test1234
+AWS_REGION=us-east-1
+S3_BUCKET=dreamingsheep-local
+NEXT_PUBLIC_S3_BUCKET=http://localhost:9000/dreamingsheep-local
+```
+
+3. Restart the dev server (`blitz dev`) and create a custom symbol with a picture on the Symbols page. Browse the bucket at [localhost:9001](http://localhost:9001) (login `test` / `test1234`).
+4. **Production is unaffected**: the S3 client only switches endpoints when `S3_ENDPOINT` is set — leave it unset outside local development.
+
+**PostgreSQL** — if you'd rather not install it natively, run just the database
+from the production compose file (mind the port-5432 and password notes in the 🐋
+section above):
+
+```sh
+docker compose -f docker-compose.production.yml up -d postgres
+```
 
 ## 🧪 Testing
 
@@ -37,63 +178,3 @@ Run your app in the development mode.
   PR; the E2E suite is local-only for now.
 - Philosophy (see issue #2): test the things that actually break — edge cases over
   coverage percentages.
-
-16. If you want to test emails 1) sign up with a real email (you should receive a welcome email with a confirmation code), then sign out and initiate the forgot password flow (you should receive a forgot password email with a token).
-17. For contribution guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md). For the project roadmap, see [ROADMAP.md](ROADMAP.md).
-
-## 🐋 Getting Started with Docker (on your local machine)
-
-1. Install Docker.
-2. Install the `docker-compose` command-line tool.
-3. (optional) Run `sudo usermod -aG docker <username>` (then log out, log in) or run all docker commands with `sudo`.
-4. Build the docker containers (only once): `docker compose -f docker-compose.production.yml build`.
-5. Run `docker compose -f docker-compose.production.yml up -d`.
-6. Manual seeding the DB:
-
-```sh
-# Optional commands to check if the dreamingsheep database exists:
-# docker exec -it docker-postgres-dreamingsheep bash
-# psql -U postgres
-# \l
-# \c dreamingsheep
-# \dt
-# \q
-# exit
-
-docker exec -it docker-dreamingsheep bash
-blitz prisma migrate dev
-blitz db seed
-exit
-
-# Optional coomands if the 5432 port is taken by the local Postgres:
-# sudo lsof -i :5432
-# sudo systemctl stop postgresql
-# sudo systemctl start postgresql
-```
-
-7. Open [localhost:3000](http://localhost:3000) and you should see the dreamingsheep landing page.
-8. (optional) Run `docker compose -f docker-compose.production.yml down` to stop and remove containers, networks, and volumes created by the previous command.
-9. (optional) All the docker images will require ~7GB of space:
-
-```
-REPOSITORY                        TAG       IMAGE ID       CREATED          SIZE
-dreamingsheep_blitzjs-app         latest    5d3e3afd0a22   8 minutes ago    6.16GB
-postgres                          13.4      113197da0347   23 months ago    371MB
-```
-
-10. (optional) Other useful docker commands:
-
-```sh
-docker ps
-docker compose -f docker-compose.production.yml ps
-docker images
-docker rmi <id>
-docker logs docker-dreamingsheep
-docker system prune -a
-docker volume prune
-docker compose down --rmi all
-docker volume ls
-docker volume rm my_volume
-docker exec -it docker-postgres-dreamingsheep bash
-docker exec -it docker-dreamingsheep bash
-```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,24 +10,32 @@ comment there before starting work (see [CONTRIBUTING.md](CONTRIBUTING.md)).
 - [x] Bedtime/wake-up sleep chart (the Settings "future-feature", delivered)
 - [x] Testing setup: Vitest unit tests + puppeteer E2E + CI ([#2](https://github.com/talpitoo/dreamingsheep/issues/2)) — **growing the coverage stays open to contributions!**
 - [x] Security: homepage stats aggregated in the DB, all queries/mutations scoped to their user ([#11](https://github.com/talpitoo/dreamingsheep/issues/11))
+- [x] Symbols page: pagination moved into the database ([#12](https://github.com/talpitoo/dreamingsheep/issues/12))
+- [x] Legacy TODO cleanup + quieter login/logout (no more console errors) ([#10](https://github.com/talpitoo/dreamingsheep/issues/10))
+- [x] Mobile UX polish: menu auto-collapse & tap-away, edge-to-edge charts, toggleable stats filters ([#14](https://github.com/talpitoo/dreamingsheep/issues/14))
+- [x] PWA web app manifest: "Add to home screen" installs with the proper sheep icon
+- [x] Local development in Docker (the only prerequisite is Docker) + MinIO S3 mock for symbol image uploads ([#13](https://github.com/talpitoo/dreamingsheep/issues/13))
 
 ## Phase 1: Foundation (current)
 
 - [ ] Migrate from MUI `sx={{}}` syntax to Tailwind CSS v4 ([#1](https://github.com/talpitoo/dreamingsheep/issues/1)) _(maintainer-led)_
-- [ ] Clean up TypeScript strict mode issues ([#3](https://github.com/talpitoo/dreamingsheep/issues/3)) — **contributions welcome!**
-- [ ] Clean up legacy TODO comments ([#10](https://github.com/talpitoo/dreamingsheep/issues/10)) — **contributions welcome!**
-- [ ] Symbols page: paginate in the database, not in JS ([#12](https://github.com/talpitoo/dreamingsheep/issues/12))
-- [ ] Local S3 mock for development (LocalStack) ([#13](https://github.com/talpitoo/dreamingsheep/issues/13)) — **contributions welcome!**
-- [ ] Mobile UX polish ([#14](https://github.com/talpitoo/dreamingsheep/issues/14)) — **contributions welcome!**
-- [ ] Misc bugs & small fixes ([#15](https://github.com/talpitoo/dreamingsheep/issues/15))
+- [ ] Small in-code `TODO (future-feature)` notes, roughly in priority order:
+      absolute `og:image` URLs ([`Layout.tsx`](src/core/layouts/Layout.tsx)),
+      base64-ify the PDF-export images ([`ExportDreams/helper.ts`](src/settings/components/ExportDreams/helper.ts)),
+      revisit the Settings refetch-vs-reload workaround ([`settings/index.tsx`](src/pages/settings/index.tsx)),
+      the `suppressFirstRenderFlicker` experiment ([`pages/index.tsx`](src/pages/index.tsx))
 
 ## Phase 2: Framework migration
 
 - [ ] Migrate from BlitzJS to Next.js App Router ([#4](https://github.com/talpitoo/dreamingsheep/issues/4))
 - [ ] Replace BlitzJS auth with NextAuth.js ([#5](https://github.com/talpitoo/dreamingsheep/issues/5))
+- [ ] Env files: move production off `.env.local` to `.env.production.local` + `APP_ENV` ([#23](https://github.com/talpitoo/dreamingsheep/issues/23)) — parked behind [#4](https://github.com/talpitoo/dreamingsheep/issues/4) to avoid deploy-script regressions
+- [ ] Finish TypeScript strict mode **after** the migration ([#3](https://github.com/talpitoo/dreamingsheep/issues/3)):
+      five strict-family flags are already enabled; `noImplicitAny` (~58 errors) and
+      `strictFunctionTypes` (3) remain — parked so contributions don't end up in a
+      merge-conflict graveyard with [#4](https://github.com/talpitoo/dreamingsheep/issues/4) (see the note in [`tsconfig.json`](tsconfig.json))
 
 ## Phase 3: Community features
 
 - [ ] AI dream interpreter ([#8](https://github.com/talpitoo/dreamingsheep/issues/8)) _(maintainer-led)_
-- [ ] Public API for dream data export ([#9](https://github.com/talpitoo/dreamingsheep/issues/9))
 - [ ] Post-launch promotion ([#17](https://github.com/talpitoo/dreamingsheep/issues/17))

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,9 +1,45 @@
-# TODO should be the same as `docker-compose.production.yml` with the addition of
+# Local development add-ons — currently the S3 mock for symbol image uploads
+# (issue #13; MinIO instead of LocalStack, whose free Docker images were
+# discontinued in March 2026).
+#
+# Standalone (app runs on the host via `npm run dev`, services in Docker):
+#   docker compose -f docker-compose.local.yml up -d
+#   docker compose -f docker-compose.production.yml up -d postgres   # optional: DB in Docker too
+#
+# Or as an overlay on the full stack (app + postgres + s3 mock, everything in Docker):
+#   docker compose -f docker-compose.production.yml -f docker-compose.local.yml up -d
+#
+# The app talks to the mock only when S3_ENDPOINT is set — see the
+# "Local S3 mock" block in .env.example. Production is unaffected.
+services:
+  s3-mock:
+    image: minio/minio
+    container_name: docker-s3-dreamingsheep
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: test # = AWS_ACCESS_KEY_ID in .env.local
+      MINIO_ROOT_PASSWORD: test1234 # = AWS_SECRET_ACCESS_KEY in .env.local
+    ports:
+      - "9000:9000" # S3 API → S3_ENDPOINT=http://localhost:9000
+      - "9001:9001" # web console → http://localhost:9001 (login: test / test1234)
+    volumes:
+      - s3-mock-dreamingsheep:/data # uploaded files survive restarts
+    restart: unless-stopped
 
-# TODO: Isolation for local testing: Having a local S3 mock service (s3-mock) allows you to isolate the testing without interacting with a real AWS S3 service. This is particularly useful for local development and testing scenarios.
-# s3-mock:
-#   image: atlassianlabs/localstack # the atlassianlabs/localstack Docker image is designed to provide a local, mock AWS environment with default configurations.
-#   environment:
-#     SERVICES: s3
-#   ports:
-#     - "4572:4572"
+  # one-shot init: creates the bucket and allows anonymous downloads
+  # (the browser loads symbol images straight from NEXT_PUBLIC_S3_BUCKET URLs)
+  s3-mock-init:
+    image: minio/mc
+    depends_on:
+      - s3-mock
+    entrypoint: >
+      /bin/sh -c "
+      until mc alias set local http://s3-mock:9000 test test1234; do sleep 1; done;
+      mc mb --ignore-existing local/dreamingsheep-local;
+      mc anonymous set download local/dreamingsheep-local;
+      echo 's3-mock ready: s3://dreamingsheep-local';
+      "
+
+volumes:
+  s3-mock-dreamingsheep:
+    name: volume-s3-dreamingsheep

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   postgres:
     image: postgres:13.4 # use the specific version, e.g., 13.4

--- a/src/pages/api/s3/delete-folder.ts
+++ b/src/pages/api/s3/delete-folder.ts
@@ -8,6 +8,9 @@ const s3Client = new S3Client({
     accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
   },
+  // local S3 mock for development (LocalStack, see issue #13): set e.g.
+  // S3_ENDPOINT=http://localhost:4566 — unset in production, where the real AWS endpoint is used
+  ...(process.env.S3_ENDPOINT && { endpoint: process.env.S3_ENDPOINT, forcePathStyle: true }),
 })
 
 async function recursiveDelete(prefix: string, count = 0, token?: string): Promise<number> {

--- a/src/pages/api/s3/delete.ts
+++ b/src/pages/api/s3/delete.ts
@@ -8,6 +8,9 @@ const s3Client = new S3Client({
     accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
   },
+  // local S3 mock for development (LocalStack, see issue #13): set e.g.
+  // S3_ENDPOINT=http://localhost:4566 — unset in production, where the real AWS endpoint is used
+  ...(process.env.S3_ENDPOINT && { endpoint: process.env.S3_ENDPOINT, forcePathStyle: true }),
 })
 
 async function getUserTotalSize(userId: number): Promise<number> {

--- a/src/pages/api/s3/size.ts
+++ b/src/pages/api/s3/size.ts
@@ -7,6 +7,9 @@ const s3Client = new S3Client({
     accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
   },
+  // local S3 mock for development (LocalStack, see issue #13): set e.g.
+  // S3_ENDPOINT=http://localhost:4566 — unset in production, where the real AWS endpoint is used
+  ...(process.env.S3_ENDPOINT && { endpoint: process.env.S3_ENDPOINT, forcePathStyle: true }),
 })
 
 export default api(async (req, res, ctx) => {

--- a/src/pages/api/s3/upload.ts
+++ b/src/pages/api/s3/upload.ts
@@ -20,6 +20,9 @@ const s3Client = new S3Client({
     accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
   },
+  // local S3 mock for development (LocalStack, see issue #13): set e.g.
+  // S3_ENDPOINT=http://localhost:4566 — unset in production, where the real AWS endpoint is used
+  ...(process.env.S3_ENDPOINT && { endpoint: process.env.S3_ENDPOINT, forcePathStyle: true }),
 })
 
 const MAX_FILE_SIZE = 1024 * 1024 * 3 // 3MB


### PR DESCRIPTION
## Summary

- **Docker-only route**: clone the repo with nothing but Docker installed and run everything — app, PostgreSQL, S3 mock — in containers. The README's new 🐋 section documents it command-by-command, all verified live: the *required* free-up-port-5432 step (with `network_mode: host` the app silently talks to whichever postgres owns the port), the `POSTGRES_PASSWORD` ↔ `DATABASE_URL` alignment and its bakes-into-the-volume-on-first-init trap, the `.env.local`-copied-into-the-image + `NEXT_PUBLIC_*`-inlined-at-build caveats, a minimal `.env.local` recipe, `migrate deploy` + seed, and a symbol-upload walkthrough.
- **Local S3 mock (closes #13)**: the four S3 API routes accept an `S3_ENDPOINT` env var (`endpoint` + `forcePathStyle`) — set, they target the mock; unset (production), byte-identical behavior. `docker-compose.local.yml` ships **MinIO** + a one-shot init container (bucket + anonymous downloads, since the browser loads symbol images straight from the bucket URL). MinIO instead of LocalStack because **LocalStack's free Docker images were discontinued in March 2026** — the old image refuses to boot.
- **README restructured** into three same-level pick-a-route sections: 💻 native, 🐋 all-in-Docker (with a note that production does **not** run Docker — the compose file is a future option), 🪣 dockerized dev services for the native route. Testing section moved below the routes.
- **`.env.example`**: local S3 mock block added; prose lines use `##` so block-uncommenting can't feed docker compose's strict `env_file` parser a broken line (found the hard way).
- **Compose files**: obsolete `version` attribute removed (kills the compose v2 warnings).
- **CONTRIBUTING**: pointer to the S3 mock for upload testing.
- **ROADMAP refresh**: shipped items updated (#10, #12, #14, PWA manifest, #13), deleted #9 removed, #15 delisted, #3 moved behind the App Router migration with its real status, the in-code `TODO (future-feature)` notes surfaced, and the new env-file refactor tracked as #23.

## Test plan

- `npm run lint`, `npm run type:check`, `npm test` (53 unit tests) — ✅
- full puppeteer e2e suite (29 tests / 6 files) against the compose PostgreSQL + MinIO — ✅
- upload lifecycle (upload → anonymous browser GET → quota → delete) verified against MinIO through the app's real routes, from both the host dev server and the containerized app — ✅
- Docker image builds clean; in-container `blitz prisma migrate deploy` + `blitz db seed` verified — ✅
- the maintainer reproduced the full Docker-only route from scratch (fresh volumes) — ✅

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)