### PR TITLE
feat(stats): flexible from–to range, search↔stats sync, sleep "now" buttons & more

### DIFF
--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -74,9 +74,19 @@ create a symbol on the fly via `CreateInstantSymbolContext`).
   bare (used by the PDF export in `src/settings/components/ExportDreams` /
   puppeteer). Remounts on window resize via a `key` hack.
 - `StatSymbolChart`: d3 bubble-pack of symbol usage.
-- The range ToggleButtonGroup (7 values, default `3months`, defined in
-  `src/stats/helpers/range.ts`) drives the query window and is remembered in
-  `sessionStorage` — built for issues #6/#7.
+- The range ToggleButtonGroup (`day`/`week`/`month`/`custom`/`all`, default
+  `month`, defined in `src/stats/helpers/range.ts`) drives the query window and is
+  remembered in `sessionStorage` — built for issues #6/#7. `custom` is a from–to
+  window backed by two `DreamDatePicker`s (dream-highlighted, in a `Collapse`
+  under the toggle card). One source of truth for the window:
+  `resolveRangeBounds()` (query `{gte,lte}`, or null for `all`) and
+  `resolveChartWindow()` (inclusive day span for the chart zero-fill) — used by
+  the three query sites (`StaticStatsCharts`, `AdvancedStats`, `SleepChart`) and
+  the two chart helpers (`chartsData`, `sleepChartData`). Preset math is identical
+  to the old inline logic (guarded by `range.test.ts` + the helper tests).
+- `DreamDatePicker`/`DreamCalendarDay` (`src/dreams/components/`): the
+  dream-highlighted calendar day styling, shared by the dreams-page calendar and
+  the stats from–to pickers (dream days tinted, today cyan, selected primary).
 - **Advanced charting** (opt-in via `User.advancedCharting` on Settings): the
   Stats page _replaces_ the static grid with `AdvancedStats` — a search-page-style
   filter panel (live, debounced, no submit) toggled by the "Advanced" button next

--- a/src/dreams/components/DreamCalendarDay.tsx
+++ b/src/dreams/components/DreamCalendarDay.tsx
@@ -1,0 +1,91 @@
+import React from "react"
+import { DateTime } from "luxon"
+import { styled } from "@mui/material"
+import { PickersDay, PickersDayProps } from "@mui/x-date-pickers"
+import { cyan } from "@mui/material/colors"
+
+// Shared calendar-day styling for the dreams-page calendar and the stats from/to
+// pickers: days with dreams are tinted, today is cyan, the selected day is primary.
+interface SelectedPickerDayProps extends PickersDayProps<DateTime> {
+  hasDreams?: boolean
+  numberOfDreams?: number
+  selected?: boolean
+  today?: boolean
+  debug?: string
+}
+
+export const SelectedPickersDay = styled(PickersDay, {
+  shouldForwardProp: (prop) =>
+    prop !== "hasDreams" &&
+    prop !== "selected" &&
+    prop !== "today" &&
+    prop !== "numberOfDreams" &&
+    prop !== "debug",
+})<SelectedPickerDayProps>(({ theme, hasDreams, numberOfDreams, selected, today, debug }) => ({
+  ...(hasDreams && {
+    backgroundColor: theme.palette.secondary.main,
+    color: theme.palette.common.black,
+    transform: "translate3d(0,0,0)",
+    "&:hover, &:focus": {
+      backgroundColor: theme.palette.secondary.dark,
+    },
+    "&:after": {
+      // NOTE: debug the number of dreams // NOTE: possible UTC/local timezone conflict, double-check
+      fontWeight: "bold",
+      opacity: 0.25,
+      content: debug === "true" ? `':${numberOfDreams}'` : "''",
+    },
+  }),
+  ...(today && {
+    backgroundColor: cyan[500],
+    color: theme.palette.common.white,
+    transform: "translate3d(0,0,0)",
+    "&:hover, &:focus": {
+      backgroundColor: cyan[700],
+    },
+  }),
+  ...(selected && {
+    backgroundColor: theme.palette.primary.main,
+    color: theme.palette.common.white,
+    transform: "translate3d(0,0,0)",
+    "&:hover, &:focus": {
+      backgroundColor: theme.palette.primary.dark,
+    },
+  }),
+})) as React.ComponentType<SelectedPickerDayProps>
+
+export type DreamsByMonth = Record<string, { count: number }>
+
+// renderDay helper: highlights a day for dreams / today / the given selected date
+export function renderDreamDay(
+  day: DateTime,
+  dreamsByMonth: DreamsByMonth,
+  selectedDate: DateTime | null,
+  pickersDayProps: PickersDayProps<DateTime>,
+  debug?: string
+) {
+  const isoDate = day.toISODate() ?? "" // NOTE: possible UTC/local timezone conflict, double-check
+  const entry = dreamsByMonth[isoDate]
+  const numberOfDreams = entry ? entry.count : 0
+  const hasDreams = !!entry
+  const isToday =
+    day.hasSame(DateTime.local(), "day") &&
+    day.hasSame(DateTime.local(), "month") &&
+    day.hasSame(DateTime.local(), "year")
+  const selected =
+    !!selectedDate &&
+    day.hasSame(selectedDate, "day") &&
+    day.hasSame(selectedDate, "month") &&
+    day.hasSame(selectedDate, "year")
+
+  return (
+    <SelectedPickersDay
+      {...pickersDayProps}
+      today={isToday}
+      selected={selected}
+      hasDreams={hasDreams}
+      numberOfDreams={numberOfDreams}
+      debug={debug}
+    />
+  )
+}

--- a/src/dreams/components/DreamDatePicker.tsx
+++ b/src/dreams/components/DreamDatePicker.tsx
@@ -1,0 +1,66 @@
+import React, { useMemo, useState } from "react"
+import { DateTime } from "luxon"
+import { TextField } from "@mui/material"
+import { DatePicker, PickersDayProps } from "@mui/x-date-pickers"
+import { useQuery } from "@blitzjs/rpc"
+import getDreamsByMonth from "src/dreams/queries/getDreamsByMonth"
+import { DreamsByMonth, renderDreamDay } from "src/dreams/components/DreamCalendarDay"
+
+const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+// the dreams-page calendar queries a month as [startOfMonth - 1 day, endOfMonth + 1 day]
+function monthBounds(month: DateTime): [Date, Date] {
+  return [
+    month.startOf("month").minus({ day: 1 }).startOf("day").toJSDate(),
+    month.endOf("month").plus({ day: 1 }).startOf("day").toJSDate(),
+  ]
+}
+
+export interface DreamDatePickerProps {
+  label: string
+  value: DateTime | null
+  onChange: (value: DateTime | null) => void
+  disableFuture?: boolean
+  minDate?: DateTime
+  maxDate?: DateTime
+}
+
+// A DatePicker whose calendar reuses the dreams-page day styling (dream days
+// tinted, today cyan, selected primary). Fetches one month at a time, refetching
+// as the user navigates — same cost as the dreams calendar.
+export const DreamDatePicker = ({
+  label,
+  value,
+  onChange,
+  disableFuture,
+  minDate,
+  maxDate,
+}: DreamDatePickerProps) => {
+  const [viewedMonth, setViewedMonth] = useState<DateTime>(value ?? DateTime.now())
+  const [monthStart, monthEnd] = useMemo(() => monthBounds(viewedMonth), [viewedMonth])
+
+  const [dreamsByMonth] = useQuery(getDreamsByMonth, {
+    where: { dreamAt: { gt: monthStart, lt: monthEnd } },
+    userTimezone,
+  })
+
+  return (
+    <DatePicker<DateTime>
+      label={label}
+      value={value}
+      onChange={onChange}
+      onMonthChange={(month) => setViewedMonth(month)}
+      disableFuture={disableFuture}
+      minDate={minDate}
+      maxDate={maxDate}
+      reduceAnimations
+      inputFormat="dd/MM/yyyy"
+      renderDay={(day, _selectedDays, pickersDayProps: PickersDayProps<DateTime>) =>
+        renderDreamDay(day, dreamsByMonth as DreamsByMonth, value, pickersDayProps)
+      }
+      renderInput={(params) => <TextField {...params} fullWidth size="small" />}
+    />
+  )
+}
+
+export default DreamDatePicker

--- a/src/dreams/components/DreamSearchForm.tsx
+++ b/src/dreams/components/DreamSearchForm.tsx
@@ -1,7 +1,7 @@
 export { FORM_ERROR } from "src/core/components/Form"
 import { z } from "zod"
 import { Form, FormProps } from "src/core/components/Form"
-import { Button, ButtonGroup, InputBase, Paper, Box, InputBaseProps } from "@mui/material"
+import { Button, ButtonGroup, Collapse, InputBase, Paper, Box, InputBaseProps } from "@mui/material"
 import { forwardRef, Fragment, PropsWithoutRef, Suspense, useEffect, useState } from "react"
 import { KeyboardArrowDown, Search, Settings } from "@mui/icons-material"
 import ToggleButtonField from "src/core/components/ToggleButtonField"
@@ -74,7 +74,7 @@ export function DreamSearchForm<S extends z.ZodType<any, any>>({
           <ButtonGroup size="large">
             <Button variant="outlined" endIcon={<KeyboardArrowDown />} onClick={toggle}>
               <Settings sx={{ display: { xs: "inline", sm: "none" } }} />{" "}
-              <Box sx={{ display: { xs: "none", sm: "inline" } }}>Advanced</Box>
+              <Box sx={{ display: { xs: "none", sm: "inline" } }}>Filters</Box>
             </Button>
             <Button variant="contained" type="submit" form="search-dream">
               <Search />
@@ -82,7 +82,9 @@ export function DreamSearchForm<S extends z.ZodType<any, any>>({
           </ButtonGroup>
         </Paper>
 
-        {isExpanded(openState) && (
+        {/* Collapse (same animation as the stats page's advanced panel) keeps the fields
+            mounted, so toggling never loses in-progress filter values */}
+        <Collapse in={isExpanded(openState)}>
           <Paper sx={{ mb: 2, p: 2 }}>
             <ToggleButtonField
               label="favorite"
@@ -124,7 +126,7 @@ export function DreamSearchForm<S extends z.ZodType<any, any>>({
               <SymbolsAutocomplete />
             </Suspense>
           </Paper>
-        )}
+        </Collapse>
       </Form>
     </Fragment>
   )

--- a/src/dreams/components/SymbolsAutocomplete.tsx
+++ b/src/dreams/components/SymbolsAutocomplete.tsx
@@ -112,7 +112,7 @@ export const SymbolsAutocomplete = () => {
           renderInput={(params) => (
             <Fragment>
               <FormLabel>symbols (themes, characters, setting, etc.)</FormLabel>
-              <TextField {...params} placeholder="type to search..." />
+              <TextField {...params} placeholder="type to search symbols..." />
             </Fragment>
           )}
         />

--- a/src/pages/dreams/index.tsx
+++ b/src/pages/dreams/index.tsx
@@ -19,13 +19,12 @@ import {
   CardActions,
   Container,
   Grid,
-  styled,
   TextField,
   Box,
 } from "@mui/material"
-import { PickersDay, PickersDayProps, StaticDatePicker } from "@mui/x-date-pickers"
+import { PickersDayProps, StaticDatePicker } from "@mui/x-date-pickers"
 import getDreamsByMonth from "src/dreams/queries/getDreamsByMonth"
-import { cyan } from "@mui/material/colors"
+import { renderDreamDay } from "src/dreams/components/DreamCalendarDay"
 import { DreamItemFooter, DreamList } from "src/dreams/components/DreamList"
 import { DreamForm, FORM_ERROR, FORM_RESET } from "src/dreams/components/DreamForm"
 import { SleepingTimeForm } from "src/sleepingTimes/components/SleepingTimeForm"
@@ -66,56 +65,8 @@ function getCurrentMonthRange(today: Date): [Date, Date] {
   ]
 }
 
-interface SelectedPickerDayProps extends PickersDayProps<DateTime> {
-  hasDreams?: boolean
-  numberOfDreams?: number
-  selected?: boolean
-  today?: boolean
-  debug?: string
-}
-
 // determine the user's timezone on the client-side
 const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone
-
-const SelectedPickersDay = styled(PickersDay, {
-  shouldForwardProp: (prop) =>
-    prop !== "hasDreams" &&
-    prop !== "selected" &&
-    prop !== "today" &&
-    prop !== "numberOfDreams" &&
-    prop !== "debug",
-})<SelectedPickerDayProps>(({ theme, hasDreams, numberOfDreams, selected, today, debug }) => ({
-  ...(hasDreams && {
-    backgroundColor: theme.palette.secondary.main,
-    color: theme.palette.common.black,
-    transform: "translate3d(0,0,0)",
-    "&:hover, &:focus": {
-      backgroundColor: theme.palette.secondary.dark,
-    },
-    "&:after": {
-      // NOTE: debug the number of dreams // NOTE: possible UTC/local timezone conflict, double-check
-      fontWeight: "bold",
-      opacity: 0.25,
-      content: debug === "true" ? `':${numberOfDreams}'` : "''",
-    },
-  }),
-  ...(today && {
-    backgroundColor: cyan[500],
-    color: theme.palette.common.white,
-    transform: "translate3d(0,0,0)",
-    "&:hover, &:focus": {
-      backgroundColor: cyan[700],
-    },
-  }),
-  ...(selected && {
-    backgroundColor: theme.palette.primary.main,
-    color: theme.palette.common.white,
-    transform: "translate3d(0,0,0)",
-    "&:hover, &:focus": {
-      backgroundColor: theme.palette.primary.dark,
-    },
-  }),
-})) as React.ComponentType<SelectedPickerDayProps>
 
 export const DreamsCalendar = () => {
   const router = useRouter()
@@ -138,23 +89,7 @@ export const DreamsCalendar = () => {
     day: DateTime,
     selectedDates: Array<DateTime | null>,
     pickersDayProps: PickersDayProps<DateTime>
-  ) => {
-    const isoDate = day.toISODate() // NOTE: possible UTC/local timezone conflict, double-check
-    const numberOfDreams = dreamsByMonth[isoDate] ? dreamsByMonth[isoDate].count : 0
-    const hasDreams = !!dreamsByMonth[isoDate] // boolean
-    const currentDate =
-      day.hasSame(DateTime.local(), "day") &&
-      day.hasSame(DateTime.local(), "month") &&
-      day.hasSame(DateTime.local(), "year")
-    const selected =
-      day.hasSame(DateTime.fromJSDate(today), "day") &&
-      day.hasSame(DateTime.fromJSDate(today), "month") &&
-      day.hasSame(DateTime.fromJSDate(today), "year")
-
-    const props = { today: currentDate, selected, hasDreams, numberOfDreams, debug: debugParam }
-
-    return <SelectedPickersDay {...pickersDayProps} {...props} />
-  }
+  ) => renderDreamDay(day, dreamsByMonth, DateTime.fromJSDate(today), pickersDayProps, debugParam)
 
   return (
     <StaticDatePicker<DateTime>

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image"
+import Link from "next/link"
 import { useRouter } from "next/router"
 import { usePaginatedQuery, useQuery } from "@blitzjs/rpc"
 import { BlitzPage, Routes } from "@blitzjs/next"
@@ -8,7 +9,7 @@ import getDreams from "src/dreams/queries/getDreams"
 import React, { Fragment, Suspense, useMemo } from "react"
 import titleSearch from "public/assets/title-search.png"
 import sheepSearch from "public/assets/sheep-search.png"
-import { Container, Grid, Typography, Box } from "@mui/material"
+import { Button, Container, Grid, Typography, Box } from "@mui/material"
 import { DreamTime, DreamType, RecallTime, Symbol } from "db"
 import { DreamList } from "src/dreams/components/DreamList"
 import { DreamSearchForm } from "src/dreams/components/DreamSearchForm"
@@ -76,6 +77,14 @@ const SearchPage: BlitzPage = () => {
     }
   }, [router.query, symbols])
 
+  // the current search filters, in the shared URL param format, for the "View stats" deep link
+  const statsQuery = useMemo(() => {
+    const keys = ["q", "favorite", "time", "mood", "recall", "type", "symbols"]
+    return Object.fromEntries(
+      keys.filter((key) => router.query[key]).map((key) => [key, router.query[key] as string])
+    )
+  }, [router.query])
+
   function search(data) {
     router.push(
       Routes.SearchPage({
@@ -138,6 +147,16 @@ const SearchPage: BlitzPage = () => {
             <Suspense fallback={<LoadingSpiral />}>
               <SearchList />
             </Suspense>
+
+            {/* mirrors the stats page's "View as list": carries the current filters over.
+                the stats page defaults to the "all" range for these (search has no range) */}
+            {user?.advancedCharting && (
+              <Box sx={{ mt: 2, textAlign: "right" }}>
+                <Link href={Routes.StatsPage(statsQuery)} passHref={true}>
+                  <Button variant="contained">View stats</Button>
+                </Link>
+              </Box>
+            )}
           </Grid>
         </Grid>
       </Container>

--- a/src/pages/stats/index.tsx
+++ b/src/pages/stats/index.tsx
@@ -6,22 +6,37 @@ import { useRouter } from "next/router"
 import React, { Fragment, Suspense, useEffect, useMemo, useState } from "react"
 import { useCurrentUser } from "src/core/hooks/useCurrentUser"
 import Layout from "src/core/layouts/Layout"
-import { Button, Container, Grid, Card, ToggleButtonGroup, ToggleButton, Box } from "@mui/material"
+import {
+  Button,
+  Collapse,
+  Container,
+  Grid,
+  Card,
+  ToggleButtonGroup,
+  ToggleButton,
+  Box,
+} from "@mui/material"
 import { KeyboardArrowDown, Settings } from "@mui/icons-material"
+import { DateTime } from "luxon"
 import titleStats from "public/assets/title-stats.png"
 import sheepStats from "public/assets/sheep-stats.png"
 import getDreams from "src/dreams/queries/getDreams"
 import { StatGoogleChart } from "src/stats/components/StatGoogleChart"
-import moment from "moment"
 import { StatSymbolChart } from "src/stats/components/StatSymbolChart"
 import { AdvancedStats } from "src/stats/components/AdvancedStats"
 import { SleepChart } from "src/stats/components/SleepChart"
+import { DreamDatePicker } from "src/dreams/components/DreamDatePicker"
 import { setChartsData } from "src/stats/helpers/chartsData"
 import {
+  CustomRange,
+  DEFAULT_RANGE,
   Range,
   RANGE_TO_DAYS,
   RANGE_BUTTONS,
+  resolveRangeBounds,
+  isCompleteCustomRange,
   STATS_RANGE_STORAGE_KEY,
+  STATS_CUSTOM_RANGE_STORAGE_KEY,
   ADVANCED_STATS_PANEL_STORAGE_KEY,
 } from "src/stats/helpers/range"
 import LoadingSpiral from "src/core/components/LoadingSpiral"
@@ -31,21 +46,16 @@ import LoadingSpiral from "src/core/components/LoadingSpiral"
 // NOTE: kept for backwards compatibility, the implementation moved to src/stats/helpers/chartsData
 export { setChartsData } from "src/stats/helpers/chartsData"
 
-const StaticStatsCharts = ({ range }: { range: Range }) => {
-  const currentMoment = moment().set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
+const StaticStatsCharts = ({ range, custom }: { range: Range; custom: CustomRange | null }) => {
+  const bounds = resolveRangeBounds(range, custom)
   const [{ dreams }, { isLoading }] = useQuery(getDreams, {
     orderBy: { dreamAt: "asc" },
     where: {
-      ...(range !== "all" && {
-        dreamAt: {
-          gte: currentMoment.clone().subtract(RANGE_TO_DAYS[range]!, "days").toISOString(),
-          lte: currentMoment.clone().add(1, "days").toISOString(),
-        },
-      }),
+      ...(bounds && { dreamAt: bounds }),
     },
   })
   const chartsData = useMemo(() => {
-    return setChartsData(range, dreams)
+    return setChartsData(range, dreams, custom)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dreams])
 
@@ -85,23 +95,70 @@ export const Stats = () => {
   const user = useCurrentUser()
   // const theme = useTheme()
   // const breakpointSm = useMediaQuery(theme.breakpoints.down("sm"))
-  const [range, setRange] = useState<Range>("3months")
-  // advanced filter panel, toggled like the search page's "Advanced" button
+  const [range, setRange] = useState<Range>(DEFAULT_RANGE)
+  // the from–to window backing the "custom" range
+  const [custom, setCustom] = useState<CustomRange | null>(null)
+  // advanced filter panel, toggled like the search page's "Filters" button
   const [advancedOpen, setAdvancedOpen] = useState(false)
 
-  // restore the last selected range + panel state within this browser session
+  // restore the last selected range + custom window + panel state within this browser
+  // session; arriving via the search page's "View stats" (filters in the URL) overrides
+  // both: search has no day/week/month/… filter, so the range defaults to "all" and the
+  // panel opens once so the carried-over filters are visible
   useEffect(() => {
+    if (!router.isReady) return
+    let savedCustom: CustomRange | null = null
+    try {
+      savedCustom = JSON.parse(
+        window.sessionStorage.getItem(STATS_CUSTOM_RANGE_STORAGE_KEY) ?? "null"
+      )
+    } catch (error) {
+      savedCustom = null
+    }
+    if (isCompleteCustomRange(savedCustom)) setCustom(savedCustom)
+
+    const cameWithFilters =
+      user?.advancedCharting &&
+      ["q", "favorite", "time", "mood", "recall", "type", "symbols"].some(
+        (key) => router.query[key]
+      )
+    if (cameWithFilters) {
+      changeRange("all")
+      setAdvancedOpen(true)
+      window.sessionStorage.setItem(ADVANCED_STATS_PANEL_STORAGE_KEY, "true")
+      return
+    }
     const saved = window.sessionStorage.getItem(STATS_RANGE_STORAGE_KEY)
-    if (saved && saved in RANGE_TO_DAYS) {
+    // only restore "custom" if a complete window was saved with it
+    if (saved === "custom" ? isCompleteCustomRange(savedCustom) : saved && saved in RANGE_TO_DAYS) {
       setRange(saved as Range)
     }
     setAdvancedOpen(window.sessionStorage.getItem(ADVANCED_STATS_PANEL_STORAGE_KEY) === "true")
-  }, [])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.isReady])
 
   function changeRange(value: Range) {
     setRange(value)
     window.sessionStorage.setItem(STATS_RANGE_STORAGE_KEY, value)
   }
+
+  function changeCustom(next: Partial<CustomRange>) {
+    const merged = { from: custom?.from ?? "", to: custom?.to ?? "", ...next }
+    setCustom(merged)
+    window.sessionStorage.setItem(STATS_CUSTOM_RANGE_STORAGE_KEY, JSON.stringify(merged))
+  }
+
+  // the custom toggle's label is the chosen span once both ends are set, else a prompt
+  const customLabel = isCompleteCustomRange(custom)
+    ? `${DateTime.fromISO(custom.from).toFormat("d MMM")} – ${DateTime.fromISO(custom.to).toFormat(
+        "d MMM"
+      )}`
+    : "from–to"
+  const customShortLabel = isCompleteCustomRange(custom)
+    ? `${DateTime.fromISO(custom.from).toFormat("d/M")}–${DateTime.fromISO(custom.to).toFormat(
+        "d/M"
+      )}`
+    : "↔"
 
   function toggleAdvanced() {
     setAdvancedOpen((prev) => {
@@ -172,7 +229,14 @@ export const Stats = () => {
                     }
                   }}
                 >
-                  {RANGE_BUTTONS.map(({ value, label, shortLabel }) => (
+                  {/* day/week/month — [from–to] — all: the custom toggle is a direct child
+                      of the group (Fragments would break MUI's child cloning) so it stays
+                      between month and all; its label becomes the chosen span once set */}
+                  {[
+                    ...RANGE_BUTTONS.filter((button) => button.value !== "all"),
+                    { value: "custom" as Range, label: customLabel, shortLabel: customShortLabel },
+                    ...RANGE_BUTTONS.filter((button) => button.value === "all"),
+                  ].map(({ value, label, shortLabel }) => (
                     <ToggleButton
                       key={value}
                       value={value}
@@ -191,7 +255,7 @@ export const Stats = () => {
                   ))}
                 </ToggleButtonGroup>
               </Card>
-              {/* range buttons left — gap — Advanced toggle (search-page pattern);
+              {/* range buttons left — gap — Filters toggle (search-page pattern);
                   the filter panel expands above all charts */}
               {user?.advancedCharting && (
                 <Card className="bg-white inline-block">
@@ -212,12 +276,43 @@ export const Stats = () => {
                   >
                     <Settings sx={{ display: { xs: "inline", sm: "none" } }} />
                     <Box component="span" sx={{ display: { xs: "none", sm: "inline" } }}>
-                      Advanced
+                      Filters
                     </Box>
                   </Button>
                 </Card>
               )}
             </Box>
+
+            {/* the from–to window for the "custom" range — expands (same Collapse animation
+                as the Filters panel) with two dream-highlighted date pickers */}
+            <Collapse in={range === "custom"}>
+              <Card className="bg-white" sx={{ mt: 2, p: 2 }}>
+                <Grid container spacing={2}>
+                  <Grid item xs={12} sm={6}>
+                    <DreamDatePicker
+                      label="from"
+                      value={custom?.from ? DateTime.fromISO(custom.from) : null}
+                      onChange={(value) =>
+                        value?.isValid && changeCustom({ from: value.toISODate()! })
+                      }
+                      disableFuture
+                      maxDate={custom?.to ? DateTime.fromISO(custom.to) : undefined}
+                    />
+                  </Grid>
+                  <Grid item xs={12} sm={6}>
+                    <DreamDatePicker
+                      label="to"
+                      value={custom?.to ? DateTime.fromISO(custom.to) : null}
+                      onChange={(value) =>
+                        value?.isValid && changeCustom({ to: value.toISODate()! })
+                      }
+                      disableFuture
+                      minDate={custom?.from ? DateTime.fromISO(custom.from) : undefined}
+                    />
+                  </Grid>
+                </Grid>
+              </Card>
+            </Collapse>
           </Grid>
         </Grid>
 
@@ -229,11 +324,11 @@ export const Stats = () => {
                 the filter panel and the charts */}
             {user?.advancedCharting ? (
               <Suspense fallback={<LoadingSpiral />}>
-                <AdvancedStats range={range} filtersOpen={advancedOpen}>
+                <AdvancedStats range={range} custom={custom} filtersOpen={advancedOpen}>
                   {user?.trackSleepingTime && (
                     <Box sx={{ mb: 3 }}>
                       <Suspense fallback={<LoadingSpiral />}>
-                        <SleepChart range={range} />
+                        <SleepChart range={range} custom={custom} />
                       </Suspense>
                     </Box>
                   )}
@@ -245,12 +340,12 @@ export const Stats = () => {
                 {user?.trackSleepingTime && (
                   <Box sx={{ mb: 3 }}>
                     <Suspense fallback={<LoadingSpiral />}>
-                      <SleepChart range={range} />
+                      <SleepChart range={range} custom={custom} />
                     </Suspense>
                   </Box>
                 )}
                 <Suspense fallback={<LoadingSpiral />}>
-                  <StaticStatsCharts range={range} />
+                  <StaticStatsCharts range={range} custom={custom} />
                 </Suspense>
               </Fragment>
             )}

--- a/src/pages/symbols/index.tsx
+++ b/src/pages/symbols/index.tsx
@@ -13,6 +13,7 @@ import { CreateSymbol } from "src/symbols/validations"
 import createSymbol from "src/symbols/mutations/createSymbol"
 import LoadingSpiral from "src/core/components/LoadingSpiral"
 import { SymbolsList } from "src/symbols/components/SymbolsList"
+import { SymbolJumpAutocomplete } from "src/symbols/components/SymbolJumpAutocomplete"
 import HourglassTopIcon from "@mui/icons-material/HourglassTop"
 
 const SymbolsPage: BlitzPage = () => {
@@ -60,6 +61,8 @@ const SymbolsPage: BlitzPage = () => {
               : "All symbols"}
           </Typography> */}
           <Suspense fallback={<LoadingSpiral />}>
+            {/* quick jump — the list below is paginated, this finds a symbol directly */}
+            <SymbolJumpAutocomplete />
             <SymbolsList />
           </Suspense>
           <p className="mt-6 text-right">

--- a/src/sleepingTimes/components/SleepingTimeForm.tsx
+++ b/src/sleepingTimes/components/SleepingTimeForm.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery } from "@blitzjs/rpc"
 import { Form } from "src/core/components/Form"
 export { FORM_ERROR } from "src/core/components/Form"
-import { Grid, TextField, TextFieldProps } from "@mui/material"
+import { Button, Grid, TextField, TextFieldProps } from "@mui/material"
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns"
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider"
 import { TimePicker, TimePickerProps } from "@mui/x-date-pickers/TimePicker"
@@ -28,6 +28,17 @@ function getISODateString(date: Date | null) {
   return null
 }
 
+// the current time snapped to the historic 5-minute grid: wake-up rounds DOWN
+// (7:08 -> 7:05 — you were already awake), bedtime rounds UP (21:03 -> 21:05 —
+// you're not asleep yet)
+function nowOnFiveMinuteGrid(rounding: "floor" | "ceil"): Date {
+  const now = new Date()
+  const minutes =
+    rounding === "ceil" ? Math.ceil(now.getMinutes() / 5) * 5 : Math.floor(now.getMinutes() / 5) * 5
+  now.setMinutes(minutes, 0, 0) // 60 rolls over into the next hour
+  return now
+}
+
 interface TimePickerFieldProps
   extends PropsWithoutRef<Omit<Partial<TimePickerProps<Date, Date>>, "variant">> {
   /** Field name. */
@@ -35,10 +46,12 @@ interface TimePickerFieldProps
   /** Field renderInput. */
   renderInput: (props: TextFieldProps) => ReactElement<any, string | JSXElementConstructor<any>>
   onChangeSubmit: (value: Date) => void
+  /** adds an inline "now" button; how the current time snaps to the 5-minute grid */
+  nowRounding?: "floor" | "ceil"
 }
 
 const TimePickerField = forwardRef<Partial<TimePickerProps<Date, Date>>, TimePickerFieldProps>(
-  ({ name, renderInput, onChangeSubmit, ...props }, ref) => {
+  ({ name, renderInput, onChangeSubmit, nowRounding, ...props }, ref) => {
     const [isOpen, setIsOpen] = useState(false)
     const [timePickerValue, setTimePickerValue] = useState<Date | null>(null)
     const {
@@ -72,7 +85,40 @@ const TimePickerField = forwardRef<Partial<TimePickerProps<Date, Date>>, TimePic
                 onChange(val)
                 setTimePickerValue(val)
               }}
-              renderInput={renderInput}
+              renderInput={(params) =>
+                renderInput(
+                  nowRounding
+                    ? {
+                        ...params,
+                        InputProps: {
+                          ...params.InputProps,
+                          endAdornment: (
+                            <Fragment>
+                              <Button
+                                size="small"
+                                color="primary"
+                                disabled={isSubmitting}
+                                sx={{ minWidth: 0, px: 1 }}
+                                // keep the tap from focusing/opening the picker (mobile
+                                // variant opens its dialog on any click into the field)
+                                onMouseDown={(event) => event.preventDefault()}
+                                onClick={(event) => {
+                                  event.stopPropagation()
+                                  const nowValue = nowOnFiveMinuteGrid(nowRounding)
+                                  onChange(nowValue)
+                                  onChangeSubmit(nowValue)
+                                }}
+                              >
+                                now
+                              </Button>
+                              {params.InputProps?.endAdornment}
+                            </Fragment>
+                          ),
+                        },
+                      }
+                    : params
+                )
+              }
               open={isOpen}
               onOpen={() => setIsOpen(true)}
               onClose={() => setIsOpen(false)}
@@ -110,6 +156,7 @@ export function SleepingTimeForm({ currentDate }: SleepingTimeFormProps) {
                 name="wakeUpTime"
                 className="translate-x-0 translate-y-0 transform-gpu"
                 minutesStep={5}
+                nowRounding="floor"
                 renderInput={(params) => (
                   <TextField
                     {...params}
@@ -148,6 +195,7 @@ export function SleepingTimeForm({ currentDate }: SleepingTimeFormProps) {
                 name="bedtime"
                 className="translate-x-0 translate-y-0 transform-gpu"
                 minutesStep={5}
+                nowRounding="ceil"
                 renderInput={(params) => (
                   <TextField
                     {...params}

--- a/src/stats/components/AdvancedStats.tsx
+++ b/src/stats/components/AdvancedStats.tsx
@@ -1,18 +1,21 @@
 import { Routes } from "@blitzjs/next"
 import { useQuery } from "@blitzjs/rpc"
-import { Box, Button, Collapse, Grid, Paper, Typography } from "@mui/material"
+import { Box, Button, Chip, Collapse, Grid, Paper, Typography } from "@mui/material"
 import { DreamTime, DreamType, RecallTime, Symbol } from "db"
 import Link from "next/link"
+import { useRouter } from "next/router"
 import moment from "moment"
 import React, { Fragment, ReactNode, Suspense, useEffect, useMemo, useState } from "react"
 import { useDebounce } from "usehooks-ts"
 import Form from "src/core/components/Form"
 import LoadingSpiral from "src/core/components/LoadingSpiral"
 import ToggleButtonField from "src/core/components/ToggleButtonField"
-import { SearchKeywordField } from "src/dreams/components/DreamSearchForm"
 import SymbolsAutocomplete from "src/dreams/components/SymbolsAutocomplete"
 import getDreams from "src/dreams/queries/getDreams"
-import { buildDreamSearchWhere } from "src/dreams/utils/buildDreamSearchWhere"
+import {
+  buildDreamSearchWhere,
+  parseDreamSearchQuery,
+} from "src/dreams/utils/buildDreamSearchWhere"
 import {
   FAVORITE_ICONS,
   MOOD_ICONS,
@@ -23,7 +26,13 @@ import {
 import { StatGoogleChart } from "src/stats/components/StatGoogleChart"
 import { StatSymbolChart } from "src/stats/components/StatSymbolChart"
 import { setChartsData } from "src/stats/helpers/chartsData"
-import { ADVANCED_STATS_FILTERS_STORAGE_KEY, Range, RANGE_TO_DAYS } from "src/stats/helpers/range"
+import {
+  ADVANCED_STATS_FILTERS_STORAGE_KEY,
+  CustomRange,
+  Range,
+  resolveRangeBounds,
+} from "src/stats/helpers/range"
+import getSymbols from "src/symbols/queries/getSymbols"
 
 interface AdvancedStatsFormValues {
   q: string
@@ -47,12 +56,19 @@ const INITIAL_VALUES: AdvancedStatsFormValues = {
 
 const AdvancedStatsQueryAndCharts = ({
   range,
+  custom,
   values,
+  keyword,
+  onClearKeyword,
 }: {
   range: Range
+  custom: CustomRange | null
   values: AdvancedStatsFormValues
+  /** the live (undebounced) keyword, only shown — filtering uses values.q */
+  keyword: string
+  onClearKeyword: () => void
 }) => {
-  const currentMoment = moment().set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
+  const bounds = resolveRangeBounds(range, custom)
   const [{ dreams, count }] = useQuery(
     getDreams,
     {
@@ -68,19 +84,7 @@ const AdvancedStatsQueryAndCharts = ({
             type: values.type,
             symbolIds: (values.symbols ?? []).map((symbol) => symbol.id),
           }),
-          ...(range !== "all"
-            ? [
-                {
-                  dreamAt: {
-                    gte: currentMoment
-                      .clone()
-                      .subtract(RANGE_TO_DAYS[range]!, "days")
-                      .toISOString(),
-                    lte: currentMoment.clone().add(1, "days").toISOString(),
-                  },
-                },
-              ]
-            : []),
+          ...(bounds ? [{ dreamAt: bounds }] : []),
         ],
       },
     },
@@ -90,16 +94,34 @@ const AdvancedStatsQueryAndCharts = ({
   // facet breakdowns of the filtered subset: "for these dreams, how do the
   // other dimensions distribute?" (e.g. symbol 'dao' -> mostly night? mostly lucid?)
   const facetsData = useMemo(() => {
-    return setChartsData(range, dreams)
+    return setChartsData(range, dreams, custom)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [range, dreams])
+  }, [range, custom, dreams])
 
   return (
     <Fragment>
       {/* the only feedback that the filters are narrowing things down while the panel is
-          collapsed; same style as the search page's result count */}
+          collapsed; same style as the search page's result count. The keyword chip is the
+          searched words carried over from the search page — deletable here, editable there */}
       <Typography variant="h4" sx={{ color: "white", mb: 1 }} component="p">
         {count} matching dream{count === 1 ? "" : "s"}
+        {keyword && (
+          <Chip
+            variant="outlined"
+            label={`"${keyword}"`}
+            onDelete={onClearKeyword}
+            sx={{
+              ml: 1.5,
+              verticalAlign: "middle",
+              color: "white",
+              borderColor: "white",
+              "& .MuiChip-deleteIcon": {
+                color: "rgba(255, 255, 255, 0.7)",
+                "&:hover": { color: "white" },
+              },
+            }}
+          />
+        )}
       </Typography>
       <Grid container spacing={3}>
         {/* facet layout mirrors the static stats grid */}
@@ -160,37 +182,89 @@ function normalizeValues(values: Partial<AdvancedStatsFormValues>): AdvancedStat
 
 export interface AdvancedStatsProps {
   range: Range
+  custom?: CustomRange | null
   /** the filter panel toggles from the Stats page header row (search-page pattern) */
   filtersOpen?: boolean
   /** rendered between the filter panel and the charts (e.g. the sleep chart) */
   children?: ReactNode
 }
 
-export const AdvancedStats = ({ range, filtersOpen = true, children }: AdvancedStatsProps) => {
-  // null until the sessionStorage restore ran, so the form mounts with the saved filters
+export const AdvancedStats = ({
+  range,
+  custom = null,
+  filtersOpen = true,
+  children,
+}: AdvancedStatsProps) => {
+  const router = useRouter()
+  // null until the sessionStorage/URL restore ran, so the form mounts with the saved filters
   const [initialValues, setInitialValues] = useState<AdvancedStatsFormValues | null>(null)
   const [formValues, setFormValues] = useState<AdvancedStatsFormValues>(INITIAL_VALUES)
+  // the keyword lives OUTSIDE the form: there's no search field on the stats page —
+  // it only arrives via the search page's "View stats" (or sessionStorage) and is
+  // cleared via the chip next to the count
+  const [keyword, setKeyword] = useState("")
+
+  // filters arriving from the search page in the shared URL param format
+  const incoming = useMemo(() => parseDreamSearchQuery(router.query), [router.query])
+  const [{ symbols: incomingSymbols }] = useQuery(getSymbols, {
+    where: { id: { in: incoming.symbolIds } },
+  })
+
+  const filterValues = useMemo(() => ({ ...formValues, q: keyword }), [formValues, keyword])
   // one debounce for the whole form: keystrokes settle, toggles feel instant
-  const debouncedValues = useDebounce(formValues, 400)
+  const debouncedValues = useDebounce(filterValues, 400)
 
   useEffect(() => {
-    let saved: Partial<AdvancedStatsFormValues> | null = null
-    try {
-      saved = JSON.parse(
-        window.sessionStorage.getItem(ADVANCED_STATS_FILTERS_STORAGE_KEY) ?? "null"
-      )
-    } catch (error) {
-      saved = null
+    if (!router.isReady || initialValues) return
+    const cameWithFilters = ["q", "favorite", "time", "mood", "recall", "type", "symbols"].some(
+      (key) => router.query[key]
+    )
+    let values: AdvancedStatsFormValues
+    if (cameWithFilters) {
+      values = normalizeValues({
+        q: incoming.q,
+        favorite: incoming.favorite,
+        time: incoming.time as DreamTime[],
+        mood: incoming.mood as number[],
+        recall: incoming.recall as RecallTime[],
+        type: incoming.type as DreamType[],
+        symbols: incomingSymbols as Symbol[],
+      })
+    } else {
+      let saved: Partial<AdvancedStatsFormValues> | null = null
+      try {
+        saved = JSON.parse(
+          window.sessionStorage.getItem(ADVANCED_STATS_FILTERS_STORAGE_KEY) ?? "null"
+        )
+      } catch (error) {
+        saved = null
+      }
+      values = normalizeValues(saved ?? {})
     }
-    const values = normalizeValues(saved ?? {})
     setInitialValues(values)
-    setFormValues(values)
-  }, [])
+    setFormValues({ ...values, q: "" })
+    setKeyword(values.q)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.isReady, initialValues, incomingSymbols])
+
+  // persist the combined filters (toggles + keyword) once the restore has run
+  useEffect(() => {
+    if (!initialValues) return
+    window.sessionStorage.setItem(ADVANCED_STATS_FILTERS_STORAGE_KEY, JSON.stringify(filterValues))
+  }, [filterValues, initialValues])
 
   function onValuesChange(values: Partial<AdvancedStatsFormValues>) {
-    const normalized = normalizeValues(values)
-    setFormValues(normalized)
-    window.sessionStorage.setItem(ADVANCED_STATS_FILTERS_STORAGE_KEY, JSON.stringify(normalized))
+    // the form has no keyword field — ignore any stale q from the form's defaultValues
+    setFormValues({ ...normalizeValues(values), q: "" })
+  }
+
+  function clearKeyword() {
+    setKeyword("")
+    // also strip q from the URL, so a refresh doesn't resurrect it
+    if (router.query.q) {
+      const { q: _q, ...rest } = router.query
+      router.replace({ query: rest }, undefined, { shallow: true })
+    }
   }
 
   if (!initialValues) {
@@ -204,18 +278,8 @@ export const AdvancedStats = ({ range, filtersOpen = true, children }: AdvancedS
             filter values survive toggling the panel */}
         <Collapse in={filtersOpen} id="advanced-stats-panel">
           <Paper sx={{ mb: 2, p: 2 }}>
-            <SearchKeywordField
-              sx={{
-                mb: 4,
-                px: 1,
-                width: "100%",
-                border: 1,
-                borderColor: "grey.400",
-                borderRadius: 1,
-              }}
-              name="q"
-              placeholder="Search..."
-            />
+            {/* NOTE: no keyword field on purpose — searching for words happens on the
+                Search page, which carries them over via its "View stats" button */}
             <ToggleButtonField
               label="favorite"
               name="favorite"
@@ -262,7 +326,13 @@ export const AdvancedStats = ({ range, filtersOpen = true, children }: AdvancedS
       {children}
 
       <Suspense fallback={<LoadingSpiral />}>
-        <AdvancedStatsQueryAndCharts range={range} values={debouncedValues} />
+        <AdvancedStatsQueryAndCharts
+          range={range}
+          custom={custom}
+          values={debouncedValues}
+          keyword={keyword}
+          onClearKeyword={clearKeyword}
+        />
       </Suspense>
     </Fragment>
   )

--- a/src/stats/components/SleepChart.tsx
+++ b/src/stats/components/SleepChart.tsx
@@ -1,11 +1,15 @@
 import { useQuery } from "@blitzjs/rpc"
 import { Box, Card, CardContent, Checkbox, FormControlLabel, Typography } from "@mui/material"
-import moment from "moment"
 import React, { useEffect, useMemo, useState } from "react"
 import { Chart } from "react-google-charts"
 import { useWindowSize } from "usehooks-ts"
 import getSleepingTimes from "src/sleepingTimes/queries/getSleepingTimes"
-import { Range, RANGE_TO_DAYS, SLEEP_CHART_STYLE_STORAGE_KEY } from "src/stats/helpers/range"
+import {
+  CustomRange,
+  Range,
+  resolveRangeBounds,
+  SLEEP_CHART_STYLE_STORAGE_KEY,
+} from "src/stats/helpers/range"
 import { SleepChartStyle, setSleepChartData } from "src/stats/helpers/sleepChartData"
 
 // matches the NIGHT color of the time chart
@@ -54,11 +58,12 @@ function options(style: SleepChartStyle, ticks: { v: number; f: string }[]): Rec
 
 export interface SleepChartProps {
   range: Range
+  custom?: CustomRange | null
 }
 
 // full-width bedtime/wake-up chart: bottom edge = bedtime, top edge = wake-up
 // time, per day; days with incomplete tracking stay uncolored
-export const SleepChart = ({ range }: SleepChartProps) => {
+export const SleepChart = ({ range, custom }: SleepChartProps) => {
   const [style, setStyle] = useState<SleepChartStyle>("bars")
   const [key, setkey] = useState(0)
   const size = useWindowSize()
@@ -81,27 +86,22 @@ export const SleepChart = ({ range }: SleepChartProps) => {
     window.sessionStorage.setItem(SLEEP_CHART_STYLE_STORAGE_KEY, value)
   }
 
-  const currentMoment = moment().set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
+  const bounds = resolveRangeBounds(range, custom)
   const [sleepingTimes] = useQuery(
     getSleepingTimes,
     {
       orderBy: { sleepingAt: "asc" },
       where: {
-        ...(range !== "all" && {
-          sleepingAt: {
-            gte: currentMoment.clone().subtract(RANGE_TO_DAYS[range]!, "days").toISOString(),
-            lte: currentMoment.clone().add(1, "days").toISOString(),
-          },
-        }),
+        ...(bounds && { sleepingAt: bounds }),
       },
     },
     { keepPreviousData: true }
   )
 
   const { data, ticks, hasData } = useMemo(() => {
-    return setSleepChartData(range, sleepingTimes, style)
+    return setSleepChartData(range, sleepingTimes, style, custom)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [range, sleepingTimes, style])
+  }, [range, custom, sleepingTimes, style])
 
   return (
     <Card className="bg-white translate-x-0 translate-y-0 transform-gpu">

--- a/src/stats/components/StatSymbolChart.tsx
+++ b/src/stats/components/StatSymbolChart.tsx
@@ -10,6 +10,18 @@ export interface StatSymbolChartProps {
   isPdf?: boolean
 }
 
+// grapheme-aware truncation: String.prototype.substring cuts emojis in half
+// (surrogate pairs / ZWJ sequences), which rendered as empty boxes in the bubbles
+function truncateLabel(label: string, maxLength: number): string {
+  const length = Math.max(1, Math.floor(maxLength))
+  if (typeof Intl !== "undefined" && "Segmenter" in Intl) {
+    const graphemes = [...new Intl.Segmenter().segment(label)].map((segment) => segment.segment)
+    return graphemes.slice(0, length).join("")
+  }
+  // fallback: code points (still keeps surrogate pairs intact)
+  return [...label].slice(0, length).join("")
+}
+
 export function StatSymbolChart({ data, isPdf = false }: StatSymbolChartProps) {
   const chartRef = useRef<HTMLDivElement>(null)
 
@@ -51,9 +63,13 @@ export function StatSymbolChart({ data, isPdf = false }: StatSymbolChartProps) {
         .append("text")
         .attr("text-anchor", "middle")
         .attr("dy", ".3em")
-        .attr("font-family", "Arial")
+        // explicit emoji fallbacks — a bare "Arial" left emojis as empty boxes
+        .attr(
+          "font-family",
+          "Arial, 'Noto Color Emoji', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif"
+        )
         .attr("font-size", "11")
-        .text((d) => d.data.symbol.substring(0, d.r / 3))
+        .text((d) => truncateLabel(d.data.symbol, d.r / 3))
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data])

--- a/src/stats/helpers/chartsData.ts
+++ b/src/stats/helpers/chartsData.ts
@@ -1,26 +1,27 @@
 import moment from "moment"
 import { Dream, DreamTime, DreamType, Symbol } from "db"
-import { Range, RANGE_TO_DAYS } from "src/stats/helpers/range"
+import { CustomRange, Range, resolveChartWindow } from "src/stats/helpers/range"
 
 // Aggregates a dreams array into the data shapes the stat charts consume.
 // Used by the static Stats grid, the advanced (filtered) facet charts and the PDF export.
-export function setChartsData(range: Range, dreams: (Dream & { symbols: Symbol[] })[]) {
-  const currentMoment = moment().set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
-
-  // find the earliest dream date
+export function setChartsData(
+  range: Range,
+  dreams: (Dream & { symbols: Symbol[] })[],
+  custom?: CustomRange | null
+) {
+  // find the earliest dream date (used for the "all" range)
   const earliestDate = dreams.reduce((earliest, dream) => {
     const dreamDate = moment(dream.dreamAt)
     return dreamDate.isBefore(earliest) ? dreamDate : earliest
   }, moment())
 
-  // calculate the number of days between the earliest date and the current date
-  const daysDifference = currentMoment.diff(earliestDate, "days") + 1
+  // inclusive [start, end] day window to zero-fill (end = today for presets, or `to` for custom)
+  const { start: windowStart, end: windowEnd } = resolveChartWindow(range, custom, earliestDate)
 
-  const subtractDays = RANGE_TO_DAYS[range] ?? daysDifference
   const dreamCount = {}
-  if (subtractDays !== null) {
-    const startMoment = currentMoment.clone().subtract(subtractDays, "days")
-    while (startMoment <= currentMoment) {
+  {
+    const startMoment = windowStart.clone()
+    while (startMoment <= windowEnd) {
       dreamCount[startMoment.format("YYYY-MM-DD")] = 0
       startMoment.add(1, "days")
     }
@@ -99,9 +100,9 @@ export function setChartsData(range: Range, dreams: (Dream & { symbols: Symbol[]
   })
 
   // fill in missing days with the middle value (3)
-  if (subtractDays !== null) {
-    const startMoment = currentMoment.clone().subtract(subtractDays, "days")
-    while (startMoment <= currentMoment) {
+  {
+    const startMoment = windowStart.clone()
+    while (startMoment <= windowEnd) {
       const key = startMoment.format("YYYY-MM-DD")
       if (!dailyMood[key]) {
         averageMood.push([moment(key).format("LL"), 3]) // Add the middle value for missing days

--- a/src/stats/helpers/range.test.ts
+++ b/src/stats/helpers/range.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import moment from "moment"
+import { isCompleteCustomRange, resolveChartWindow, resolveRangeBounds } from "./range"
+
+const NOW = new Date(2026, 6, 2, 12, 0, 0) // Thu Jul 2 2026
+const day = (m: moment.Moment) => m.format("YYYY-MM-DD")
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW)
+})
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("isCompleteCustomRange", () => {
+  it("requires both ends", () => {
+    expect(isCompleteCustomRange(null)).toBe(false)
+    expect(isCompleteCustomRange({ from: "2026-01-01", to: "" })).toBe(false)
+    expect(isCompleteCustomRange({ from: "", to: "2026-01-01" })).toBe(false)
+    expect(isCompleteCustomRange({ from: "2026-01-01", to: "2026-02-01" })).toBe(true)
+  })
+})
+
+describe("resolveRangeBounds", () => {
+  it("returns null (no bound) for the all range", () => {
+    expect(resolveRangeBounds("all")).toBeNull()
+  })
+
+  it("presets go back N days from today and up to tomorrow", () => {
+    const week = resolveRangeBounds("week")!
+    // week = 6 days back
+    expect(week.gte).toBe(moment(NOW).startOf("day").subtract(6, "days").toISOString())
+    expect(week.lte).toBe(moment(NOW).startOf("day").add(1, "days").toISOString())
+  })
+
+  it("custom uses the picked [from, to] inclusive of the whole 'to' day", () => {
+    const bounds = resolveRangeBounds("custom", { from: "2026-06-01", to: "2026-06-10" })!
+    expect(bounds.gte).toBe(moment("2026-06-01").startOf("day").toISOString())
+    // lte is the START of the day after 'to', so the whole 'to' day is included
+    expect(bounds.lte).toBe(moment("2026-06-11").startOf("day").toISOString())
+  })
+
+  it("incomplete custom falls back to the default (month) range", () => {
+    expect(resolveRangeBounds("custom", { from: "2026-06-01", to: "" })).toEqual(
+      resolveRangeBounds("month")
+    )
+    expect(resolveRangeBounds("custom", null)).toEqual(resolveRangeBounds("month"))
+  })
+})
+
+describe("resolveChartWindow", () => {
+  const earliest = moment("2026-01-01")
+
+  it("presets end today and start N days back", () => {
+    const { start, end } = resolveChartWindow("week", null, earliest)
+    expect(day(end)).toBe(day(moment(NOW)))
+    expect(day(start)).toBe(day(moment(NOW).subtract(6, "days")))
+  })
+
+  it("all starts one day before the earliest data (parity with the old logic)", () => {
+    const { start, end } = resolveChartWindow("all", null, earliest)
+    expect(day(end)).toBe(day(moment(NOW)))
+    // old code: subtractDays = today.diff(earliest) + 1  ->  start = earliest - 1 day
+    const expected = moment(NOW)
+      .startOf("day")
+      .subtract(moment(NOW).startOf("day").diff(earliest, "days") + 1, "days")
+    expect(day(start)).toBe(day(expected))
+  })
+
+  it("custom spans exactly [from, to]", () => {
+    const { start, end } = resolveChartWindow(
+      "custom",
+      { from: "2026-06-01", to: "2026-06-10" },
+      earliest
+    )
+    expect(day(start)).toBe("2026-06-01")
+    expect(day(end)).toBe("2026-06-10")
+  })
+
+  it("incomplete custom falls back to the default (month) window", () => {
+    const fallback = resolveChartWindow("month", null, earliest)
+    const incomplete = resolveChartWindow("custom", { from: "2026-06-01", to: "" }, earliest)
+    expect(day(incomplete.start)).toBe(day(fallback.start))
+    expect(day(incomplete.end)).toBe(day(fallback.end))
+  })
+})

--- a/src/stats/helpers/range.ts
+++ b/src/stats/helpers/range.ts
@@ -1,28 +1,86 @@
-export type Range = "day" | "week" | "month" | "3months" | "6months" | "1year" | "all"
+import moment from "moment"
+
+export type Range = "day" | "week" | "month" | "custom" | "all"
+
+// a user-picked [from, to] window (yyyy-MM-dd), used when range === "custom"
+export interface CustomRange {
+  from: string
+  to: string
+}
 
 // sessionStorage keys: remembered per browser tab/session, clean slate on a fresh visit
 export const STATS_RANGE_STORAGE_KEY = "dreamingsheep.stats.range"
+export const STATS_CUSTOM_RANGE_STORAGE_KEY = "dreamingsheep.stats.customRange"
 export const ADVANCED_STATS_FILTERS_STORAGE_KEY = "dreamingsheep.stats.advancedFilters"
 export const ADVANCED_STATS_PANEL_STORAGE_KEY = "dreamingsheep.stats.advancedPanel"
 export const SLEEP_CHART_STYLE_STORAGE_KEY = "dreamingsheep.stats.sleepChartStyle"
 
-// days to subtract from "today"; null = no lower bound (all time)
-export const RANGE_TO_DAYS: Record<Range, number | null> = {
+export const DEFAULT_RANGE: Range = "month"
+
+// days to subtract from "today" for the preset ranges; null = no lower bound (all time).
+// "custom" is resolved from its {from, to} window, not from here.
+export const RANGE_TO_DAYS: Record<Exclude<Range, "custom">, number | null> = {
   day: 0,
   week: 6,
   month: 31,
-  "3months": 91,
-  "6months": 182,
-  "1year": 365,
   all: null,
 }
 
-export const RANGE_BUTTONS: { value: Range; label: string; shortLabel: string }[] = [
+// the preset toggle buttons, in display order; the "custom" (from–to) toggle is
+// rendered separately by the Stats page because its label is the chosen span
+export const RANGE_BUTTONS: {
+  value: Exclude<Range, "custom">
+  label: string
+  shortLabel: string
+}[] = [
   { value: "day", label: "day", shortLabel: "day" },
   { value: "week", label: "week", shortLabel: "week" },
   { value: "month", label: "month", shortLabel: "month" },
-  { value: "3months", label: "3 months", shortLabel: "3m" },
-  { value: "6months", label: "6 months", shortLabel: "6m" },
-  { value: "1year", label: "1 year", shortLabel: "1y" },
   { value: "all", label: "all", shortLabel: "all" },
 ]
+
+const startOfDay = (value: moment.MomentInput) =>
+  moment(value).set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
+
+export function isCompleteCustomRange(custom?: CustomRange | null): custom is CustomRange {
+  return !!custom && !!custom.from && !!custom.to
+}
+
+// inclusive day-level [start, end] moments for the chart zero-fill loops.
+// `earliest` is the earliest data point (used only for the "all" range).
+// Preset math is byte-identical to the old inline logic (end = today, go back N days).
+export function resolveChartWindow(
+  range: Range,
+  custom: CustomRange | null | undefined,
+  earliest: moment.Moment
+): { start: moment.Moment; end: moment.Moment } {
+  const today = startOfDay(moment())
+  if (range === "custom" && isCompleteCustomRange(custom)) {
+    return { start: startOfDay(custom.from), end: startOfDay(custom.to) }
+  }
+  // incomplete custom falls back to the default preset so charts never break
+  const preset = range === "custom" ? DEFAULT_RANGE : range
+  const subtractDays = RANGE_TO_DAYS[preset] ?? today.diff(earliest, "days") + 1
+  return { start: today.clone().subtract(subtractDays, "days"), end: today }
+}
+
+// ISO {gte, lte} bounds for the dreamAt/sleepingAt query filter, or null for no
+// bound ("all"). Preset bounds match the old inline query math exactly.
+export function resolveRangeBounds(
+  range: Range,
+  custom?: CustomRange | null
+): { gte: string; lte: string } | null {
+  if (range === "all") return null
+  if (range === "custom") {
+    if (!isCompleteCustomRange(custom)) return resolveRangeBounds(DEFAULT_RANGE)
+    return {
+      gte: startOfDay(custom.from).toISOString(),
+      lte: startOfDay(custom.to).add(1, "days").toISOString(),
+    }
+  }
+  const today = startOfDay(moment())
+  return {
+    gte: today.clone().subtract(RANGE_TO_DAYS[range]!, "days").toISOString(),
+    lte: today.clone().add(1, "days").toISOString(),
+  }
+}

--- a/src/stats/helpers/sleepChartData.ts
+++ b/src/stats/helpers/sleepChartData.ts
@@ -1,6 +1,6 @@
 import moment from "moment"
 import { SleepingTime } from "db"
-import { Range, RANGE_TO_DAYS } from "src/stats/helpers/range"
+import { CustomRange, Range, resolveChartWindow } from "src/stats/helpers/range"
 
 export type SleepChartStyle = "bars" | "band"
 
@@ -29,14 +29,14 @@ export function formatClock(value: number) {
 export function setSleepChartData(
   range: Range,
   sleepingTimes: SleepingTime[],
-  style: SleepChartStyle
+  style: SleepChartStyle,
+  custom?: CustomRange | null
 ) {
-  const currentMoment = moment().set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
   const earliestDate = sleepingTimes.reduce((earliest, sleepingTime) => {
     const sleepingDate = moment(sleepingTime.sleepingAt)
     return sleepingDate.isBefore(earliest) ? sleepingDate : earliest
   }, moment())
-  const subtractDays = RANGE_TO_DAYS[range] ?? currentMoment.diff(earliestDate, "days") + 1
+  const { start: windowStart, end: windowEnd } = resolveChartWindow(range, custom, earliestDate)
 
   const byDay: Record<string, SleepingTime> = {}
   sleepingTimes.forEach((sleepingTime) => {
@@ -59,8 +59,8 @@ export function setSleepChartData(
   let minHours = 0
   let maxHours = 9
 
-  const cursor = currentMoment.clone().subtract(subtractDays, "days")
-  while (cursor <= currentMoment) {
+  const cursor = windowStart.clone()
+  while (cursor <= windowEnd) {
     const key = cursor.format("YYYY-MM-DD")
     const label = cursor.format("MMM D")
     const sleepingTime = byDay[key]

--- a/src/symbols/components/SymbolJumpAutocomplete.tsx
+++ b/src/symbols/components/SymbolJumpAutocomplete.tsx
@@ -1,0 +1,70 @@
+import { useQuery } from "@blitzjs/rpc"
+import { useRouter } from "next/router"
+import { Routes } from "@blitzjs/next"
+import { Autocomplete, Box, Paper, TextField } from "@mui/material"
+import { Symbol } from "db"
+import React from "react"
+import { useCurrentUser } from "src/core/hooks/useCurrentUser"
+import getAutocompleteSymbols from "src/symbols/queries/getAutocompleteSymbols"
+
+// quick jump on the paginated Symbols page: picking a symbol navigates to
+// /symbols?id=<id>, which resolves its page and expands the card — the same
+// flow as following a symbol link from a dream
+export const SymbolJumpAutocomplete = () => {
+  const user = useCurrentUser()
+  const router = useRouter()
+  const [{ symbols }, { isLoading }] = useQuery(
+    getAutocompleteSymbols,
+    {
+      orderBy: { name: "asc" },
+      where: { OR: [{ relatedTo: { some: { id: user?.id } } }, { authorId: user?.id }] },
+      take: 200,
+    },
+    { queryKey: ["get-symbols-autocomplete"] }
+  )
+
+  return (
+    <Paper sx={{ mb: 7, p: 1 }}>
+      <Autocomplete
+        options={symbols as Symbol[]}
+        autoHighlight
+        handleHomeEndKeys
+        loading={isLoading}
+        // stays empty after a pick — it's a navigation box, not a filter
+        value={null}
+        blurOnSelect
+        clearOnBlur
+        forcePopupIcon={false}
+        getOptionLabel={(option: Symbol) => option.name}
+        isOptionEqualToValue={(option: Symbol, value: Symbol) => option.id === value.id}
+        renderOption={(props, option) => (
+          <Box component="li" sx={{ "& > span": { mr: 2, flexShrink: 0 } }} {...props}>
+            {option.icon ? (
+              <span className={option.icon} />
+            ) : (
+              <span className="lucidicon lucidicon-tag"></span>
+            )}
+            {option.name}
+          </Box>
+        )}
+        onChange={(_, symbol) => {
+          if (symbol) {
+            // scroll: false — the SymbolCard smooth-scrolls itself into view; the default
+            // scroll-to-top would stomp it when the symbol is already on the current page
+            router.push(Routes.SymbolsPage({ id: symbol.id }), undefined, { scroll: false })
+          }
+        }}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            placeholder="type to find a symbol..."
+            variant="standard"
+            InputProps={{ ...params.InputProps, disableUnderline: true }}
+          />
+        )}
+      />
+    </Paper>
+  )
+}
+
+export default SymbolJumpAutocomplete

--- a/src/symbols/components/SymbolsList.tsx
+++ b/src/symbols/components/SymbolsList.tsx
@@ -51,9 +51,15 @@ export const SymbolsList = () => {
 
   useEffect(() => {
     if (!router.query.page && !isLoading && symbolPosition) {
-      router.push({
-        query: { ...router.query, page: Math.ceil(symbolPosition / ITEMS_PER_PAGE) },
-      })
+      // scroll: false — the deep-linked SymbolCard smooth-scrolls itself into view;
+      // the default scroll-to-top would cancel it when the card is already rendered
+      router.push(
+        {
+          query: { ...router.query, page: Math.ceil(symbolPosition / ITEMS_PER_PAGE) },
+        },
+        undefined,
+        { scroll: false }
+      )
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoading, symbolPosition, router])

--- a/test/e2e/isolation.e2e.test.ts
+++ b/test/e2e/isolation.e2e.test.ts
@@ -71,9 +71,11 @@ describe("cross-user isolation (dreams + symbols)", () => {
   it("dalecooper's search autocomplete doesn't offer it either", async () => {
     await dalecooper.goto(`${BASE}/search`, { waitUntil: "networkidle2" })
     await sleep(2000)
-    await clickButtonWithText(dalecooper, "Advanced")
-    await dalecooper.waitForSelector('input[placeholder="type to search..."]', { timeout: 15_000 })
-    await dalecooper.type('input[placeholder="type to search..."]', symbolName)
+    await clickButtonWithText(dalecooper, "Filters")
+    await dalecooper.waitForSelector('input[placeholder="type to search symbols..."]', {
+      timeout: 15_000,
+    })
+    await dalecooper.type('input[placeholder="type to search symbols..."]', symbolName)
     await sleep(1500)
     const options = await dalecooper.evaluate(() =>
       [...document.querySelectorAll('li[role="option"]')].map((option) =>

--- a/test/e2e/settings-stats.e2e.test.ts
+++ b/test/e2e/settings-stats.e2e.test.ts
@@ -40,10 +40,10 @@ describe("settings drive the stats page", () => {
     }
   }
 
-  it("shows all 7 range buttons", async () => {
+  it("shows all 5 range buttons (day/week/month/from–to/all)", async () => {
     originalAdvanced = await setCheckboxSetting(page, "advanced-charting")
     originalBedtime = await setCheckboxSetting(page, "bedtime")
-    expect((await statsState()).rangeButtons).toBe(7)
+    expect((await statsState()).rangeButtons).toBe(5)
   })
 
   it("advanced charting OFF -> static charts, no filter form", async () => {

--- a/test/e2e/symbols.e2e.test.ts
+++ b/test/e2e/symbols.e2e.test.ts
@@ -55,9 +55,11 @@ describe("symbols CRUD", () => {
   it("offers the new symbol in the dream form autocomplete (cross-page effect)", async () => {
     await page.goto(`${BASE}/search`, { waitUntil: "networkidle2" })
     await sleep(2000)
-    await clickButtonWithText(page, "Advanced")
-    await page.waitForSelector('input[placeholder="type to search..."]', { timeout: 15_000 })
-    await page.type('input[placeholder="type to search..."]', name)
+    await clickButtonWithText(page, "Filters")
+    await page.waitForSelector('input[placeholder="type to search symbols..."]', {
+      timeout: 15_000,
+    })
+    await page.type('input[placeholder="type to search symbols..."]', name)
     await sleep(1500)
     const options = await page.evaluate(() =>
       [...document.querySelectorAll('li[role="option"]')].map((option) =>


### PR DESCRIPTION
Syncs the stats and search pages and lands a batch of UX polish. No schema changes.

## Stats & search

- **Flexible range**: the toggle group is now `day · week · month · from–to · all` (default **month**; the 3-month/6-month/1-year presets are dropped — all expressible via from–to). The **from–to** toggle opens a `Collapse` under the toggle card with two date pickers whose calendars **reuse the dreams-page day highlighting** (dream days tinted, today cyan, selected primary); once both ends are set, the toggle's label becomes the chosen span.
- **One source of truth for the window**: `resolveRangeBounds` (query `{gte,lte}`, or null for `all`) + `resolveChartWindow` (inclusive day span for the chart zero-fill) replace the duplicated inline date math across the **3 query sites** (`StaticStatsCharts`, `AdvancedStats`, `SleepChart`) and **2 chart helpers** (`chartsData`, `sleepChartData`). Preset output is provably unchanged — guarded by a new `range.test.ts` and the existing helper tests.
- **"View stats"** on the search page (mirrors stats' "View as list"): carries the active filters over; arriving that way forces range **all** (search has no date range) and opens the filter panel.
- The stats filter panel **drops its keyword field** — word search stays on the search page — and shows a carried-over keyword as a **deletable chip** (white, next to the count) that also strips `q` from the URL.
- **"Advanced" → "Filters"** on both pages; the search page's advanced panel now uses the **same `Collapse` animation** as stats (fields stay mounted, so toggling never loses in-progress filters).

## Other UX

- **Sleep form "now" buttons**: inline buttons in both time fields — wake-up **floors** to the 5-minute grid (7:08 → 7:05), bedtime **ceils** (21:03 → 21:05), staying compatible with the historic 5-minute data. Works on mobile where there was no clock trigger before.
- **Jump-to-symbol** autocomplete under the Symbols heading: navigates to a symbol's page and expands it (same flow as a dream's symbol link). `scroll: false` on the deep-link pushes so the smooth scroll-into-view isn't stomped when the symbol is already on the current page.
- **StatSymbolChart emojis**: emoji-safe font stack + grapheme-aware truncation (`Intl.Segmenter`) — multi-emoji symbol names no longer render as empty boxes.
- Extracted `DreamCalendarDay` + `DreamDatePicker`; the **dreams page now reuses them** (its inline calendar-day styling moved into the shared module — worth a glance to confirm the dreams calendar is unchanged).

> Also included: the symbol autocomplete placeholder is now "type to search symbols..." (a working-tree edit from the maintainer); the two e2e selectors were updated to match.

## Test plan

- `npm run lint`, `npm run type:check`, `npm test` (**62 unit tests**, incl. new `range.test.ts` for the window resolvers) — ✅
- full puppeteer e2e suite (**29 tests / 6 files**) against compose PostgreSQL + MinIO — ✅ (three tests updated for the "Filters" rename, the 5-button range group, and the new placeholder)
- production `blitz build` — ✅
- manual visual review by the maintainer across all items — ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)