### PR TITLE
Collapsible navbar animation, symbol-creation gating, and the Google 499 fix

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: verify
+description: How to empirically verify UI changes in dreamingsheep — launch, login, drive with puppeteer, and known screenshot gotchas.
+---
+
+# Verifying dreamingsheep changes end-to-end
+
+## Launch
+
+The dev server is often already running — check first:
+
+```sh
+curl -s -o /dev/null -w "%{http_code}" http://localhost:3000   # 200 → running
+nvm use 18 && npm run dev                                       # otherwise (needs seeded DB: blitz db seed)
+```
+
+`next dev` hot-reloads the working tree, so edits are live without restarts
+(give it a few seconds after an edit before measuring).
+
+## Drive it with puppeteer
+
+Puppeteer is already a dependency (used by the e2e suite). From a script
+outside the repo, resolve it via the repo's node_modules:
+
+```js
+import { createRequire } from "module"
+const require = createRequire("/path/to/dreamingsheep/package.json")
+const puppeteer = require("puppeteer")
+```
+
+Login (seeded demo user, localhost only): fill `input[name="email"]` /
+`input[name="password"]` with `zhuangzi@dreamingsheep.net` / `zhuangzi`,
+press Enter, wait for navigation. See `test/e2e/helpers.ts` for the canonical
+flow and more helpers (deletion dialogs, settings cards, pagination).
+
+Useful entry points when driving flows:
+
+- Dream form: `/dreams` → "New dream" button → form is condensed; click
+  "More" to reveal time/mood/recall/type + the symbols autocomplete
+  (`input#tags-filled`). There is no `/dreams/new` route.
+- Search filters: `/search` → "Filters" button opens the Collapse panel.
+- Stats advanced panel: needs `User.advancedCharting` (Settings).
+
+## Gotchas
+
+- **`page.screenshot()` lies about sticky headers.** The default
+  `captureBeyondViewport: true` paints the sticky AppBar's contents at wrong
+  offsets (title image floating mid-page, header appearing hundreds of px
+  tall). Always pass `captureBeyondViewport: false`, and trust
+  `getBoundingClientRect()` over pixels when they disagree.
+- For layout regressions, diff DOM measurements against a baseline:
+  `git stash` → measure → `git stash pop` → measure again. Check md–lg
+  widths (~1000px) too, not just 1280/1440 — the header layout is
+  breakpoint-sensitive.
+- MUI Collapse animation can be asserted by sampling
+  `getComputedStyle(el).height` every ~60ms after triggering.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,6 @@
+# /api/ is deliberately NOT disallowed: Googlebot's renderer needs the Blitz RPC
+# calls (e.g. /api/rpc/getCurrentUser) to render pages — blocking them made the
+# root error boundary replace the page and Google indexed the error sheep.
+# The rpc endpoints are POST-only (GET returns 404), so there is nothing to crawl.
 User-agent: *
-Disallow: /api/
+Disallow:

--- a/src/core/components/CustomErrorContainer.tsx
+++ b/src/core/components/CustomErrorContainer.tsx
@@ -1,3 +1,4 @@
+import Head from "next/head"
 import Image from "next/image"
 import { ReactNode } from "react"
 import { Container, Grid, Box } from "@mui/material"
@@ -15,6 +16,11 @@ interface CustomErrorContainerProps {
 const CustomErrorContainer = ({ children }: CustomErrorContainerProps) => {
   return (
     <Container>
+      {/* error states must never be indexed — Google once indexed a transient
+          "499: Client Closed Request" render as the homepage snippet */}
+      <Head>
+        <meta name="robots" content="noindex" />
+      </Head>
       <Grid container>
         <Grid item md={2} />
         <Grid item xs={12} sm={6} md={4}>

--- a/src/core/layouts/Header.tsx
+++ b/src/core/layouts/Header.tsx
@@ -8,11 +8,13 @@ import {
   Box,
   Button,
   ClickAwayListener,
+  Collapse,
   InputAdornment,
   Menu,
   MenuItem,
   TextField,
   Toolbar,
+  useMediaQuery,
 } from "@mui/material"
 import logout from "src/auth/mutations/logout"
 import React, { Fragment, useEffect, useState } from "react"
@@ -31,6 +33,9 @@ export function Header() {
   const [query, setQuery] = useState(router.query.q ?? "")
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const theme = useTheme()
+  // noSsr: the header only renders with a session (client-side), so resolve the
+  // breakpoint immediately instead of a false-then-true double render
+  const isDesktop = useMediaQuery(theme.breakpoints.up("md"), { noSsr: true })
 
   function handleMenu(event: React.MouseEvent<HTMLElement>) {
     setAnchorEl(event.currentTarget)
@@ -100,12 +105,10 @@ export function Header() {
               className="py-3 translate-x-0 translate-y-0 transform-gpu"
               sx={{
                 minHeight: { xs: "80px" },
-                ...(expanded && {
-                  flexDirection: { xs: "column", md: "row" },
-                }),
-                ...(!expanded && {
-                  flexDirection: "row",
-                }),
+                // below md the mobile menu is a full-width Collapse that wraps to its own
+                // line; md+ must stay nowrap like before, otherwise the nav wraps under
+                // the logo at borderline widths instead of squeezing onto one row
+                flexWrap: { xs: "wrap", md: "nowrap" },
               }}
             >
               <div className="absolute top-0 left-0">
@@ -124,12 +127,9 @@ export function Header() {
               <Box
                 className="flex-grow mr-8"
                 sx={{
-                  ...(expanded && {
-                    marginLeft: { xs: "0", md: `${SQUARE_LOGO_SIZE - 30}px` },
-                  }),
-                  ...(!expanded && {
-                    marginLeft: `${SQUARE_LOGO_SIZE - 30}px`,
-                  }),
+                  // on xs the box is empty (title hidden or absolutely positioned),
+                  // so the logo offset only matters from md up
+                  marginLeft: { xs: "0", md: `${SQUARE_LOGO_SIZE - 30}px` },
                 }}
               >
                 <Link href={Routes.Home()} passHref={true}>
@@ -176,256 +176,214 @@ export function Header() {
                 </Button>
               </Fragment>
 
-              <Box
-                sx={{
-                  ...(expanded && {
-                    marginTop: { xs: "8.5rem", md: "0" },
+              {/* Collapse (same animation as the search/stats filter panels) slides the
+                  mobile menu open/closed; on md+ it's permanently open, so the desktop
+                  nav renders exactly as before */}
+              <Collapse in={expanded || isDesktop} sx={{ width: { xs: "100%", md: "auto" } }}>
+                <Box
+                  sx={{
+                    // padding (not margin — margins don't count into Collapse's measured
+                    // height) clears the absolutely positioned title image on mobile
+                    paddingTop: { xs: "8.5rem", md: 0 },
                     display: { xs: "grid", md: "flex" },
                     flexDirection: { xs: "column", md: "row" },
                     alignItems: { xs: "start", md: "center" },
                     width: { xs: "100%", md: "auto" },
-                  }),
-                  ...(!expanded && {
-                    marginTop: "0",
-                    display: { xs: "none", md: "flex" },
-                    flexDirection: "row",
-                    alignItems: "center",
-                    width: "auto",
-                  }),
-                }}
-              >
-                <Link href={Routes.DreamsPage()} passHref={true}>
-                  <Button
-                    sx={{
-                      flexShrink: 0,
-                      ...(expanded && {
+                  }}
+                >
+                  <Link href={Routes.DreamsPage()} passHref={true}>
+                    <Button
+                      sx={{
+                        flexShrink: 0,
                         mr: { xs: 0, md: 2 },
-                      }),
-                      ...(!expanded && {
-                        mr: 2,
-                      }),
-                      "&:hover": { textDecoration: "none !important" },
-                      backgroundColor:
-                        Routes.DreamsPage().pathname === router.pathname
+                        "&:hover": { textDecoration: "none !important" },
+                        backgroundColor:
+                          Routes.DreamsPage().pathname === router.pathname
+                            ? "lightgray !important"
+                            : "transparent",
+                      }}
+                      color="inherit"
+                      onClick={collapseMobileMenu}
+                      className="w-full md:w-auto text-[#202020]"
+                    >
+                      Dreams
+                    </Button>
+                  </Link>
+                  <Link href={Routes.SymbolsPage()} passHref={true}>
+                    <Button
+                      sx={{
+                        flexShrink: 0,
+                        mr: { xs: 0, md: 2 },
+                        "&:hover": { textDecoration: "none !important" },
+                        backgroundColor:
+                          Routes.SymbolsPage().pathname === router.pathname
+                            ? "lightgray !important"
+                            : "transparent",
+                      }}
+                      color="inherit"
+                      onClick={collapseMobileMenu}
+                      className="w-full md:w-auto text-[#202020]"
+                    >
+                      Symbols
+                    </Button>
+                  </Link>
+                  <Link href={Routes.StatsPage()} passHref={true}>
+                    <Button
+                      sx={{
+                        flexShrink: 0,
+                        mr: { xs: 0, md: 2 },
+                        "&:hover": { textDecoration: "none !important" },
+                        backgroundColor:
+                          Routes.StatsPage().pathname === router.pathname
+                            ? "lightgray !important"
+                            : "transparent",
+                      }}
+                      color="inherit"
+                      onClick={collapseMobileMenu}
+                      className="w-full md:w-auto text-[#202020]"
+                    >
+                      Stats
+                    </Button>
+                  </Link>
+                  <Link href={Routes.FaqPage()} passHref={true}>
+                    <Button
+                      sx={{
+                        flexShrink: 0,
+                        mr: { xs: 0, md: 2 },
+                        "&:hover": { textDecoration: "none !important" },
+                        backgroundColor:
+                          Routes.FaqPage().pathname === router.pathname
+                            ? "lightgray !important"
+                            : "transparent",
+                      }}
+                      color="inherit"
+                      onClick={collapseMobileMenu}
+                      className="w-full md:w-auto text-[#202020]"
+                    >
+                      FAQ
+                    </Button>
+                  </Link>
+                  <Link href={Routes.BlogPage()} passHref={true}>
+                    <Button
+                      sx={{
+                        flexShrink: 0,
+                        mr: { xs: 0, md: 2 },
+                        "&:hover": { textDecoration: "none !important" },
+                        backgroundColor: router.pathname.startsWith(Routes.BlogPage().pathname)
                           ? "lightgray !important"
                           : "transparent",
-                    }}
-                    color="inherit"
-                    onClick={collapseMobileMenu}
-                    className="w-full md:w-auto text-[#202020]"
-                  >
-                    Dreams
-                  </Button>
-                </Link>
-                <Link href={Routes.SymbolsPage()} passHref={true}>
-                  <Button
+                      }}
+                      color="inherit"
+                      onClick={collapseMobileMenu}
+                      className="w-full md:w-auto text-[#202020]"
+                    >
+                      Blog
+                    </Button>
+                  </Link>
+                  <TextField
                     sx={{
-                      flexShrink: 0,
-                      ...(expanded && {
-                        mr: { xs: 0, md: 2 },
-                      }),
-                      ...(!expanded && {
-                        mr: 2,
-                      }),
-                      "&:hover": { textDecoration: "none !important" },
-                      backgroundColor:
-                        Routes.SymbolsPage().pathname === router.pathname
-                          ? "lightgray !important"
-                          : "transparent",
-                    }}
-                    color="inherit"
-                    onClick={collapseMobileMenu}
-                    className="w-full md:w-auto text-[#202020]"
-                  >
-                    Symbols
-                  </Button>
-                </Link>
-                <Link href={Routes.StatsPage()} passHref={true}>
-                  <Button
-                    sx={{
-                      flexShrink: 0,
-                      ...(expanded && {
-                        mr: { xs: 0, md: 2 },
-                      }),
-                      ...(!expanded && {
-                        mr: 2,
-                      }),
-                      "&:hover": { textDecoration: "none !important" },
-                      backgroundColor:
-                        Routes.StatsPage().pathname === router.pathname
-                          ? "lightgray !important"
-                          : "transparent",
-                    }}
-                    color="inherit"
-                    onClick={collapseMobileMenu}
-                    className="w-full md:w-auto text-[#202020]"
-                  >
-                    Stats
-                  </Button>
-                </Link>
-                <Link href={Routes.FaqPage()} passHref={true}>
-                  <Button
-                    sx={{
-                      flexShrink: 0,
-                      ...(expanded && {
-                        mr: { xs: 0, md: 2 },
-                      }),
-                      ...(!expanded && {
-                        mr: 2,
-                      }),
-                      "&:hover": { textDecoration: "none !important" },
-                      backgroundColor:
-                        Routes.FaqPage().pathname === router.pathname
-                          ? "lightgray !important"
-                          : "transparent",
-                    }}
-                    color="inherit"
-                    onClick={collapseMobileMenu}
-                    className="w-full md:w-auto text-[#202020]"
-                  >
-                    FAQ
-                  </Button>
-                </Link>
-                <Link href={Routes.BlogPage()} passHref={true}>
-                  <Button
-                    sx={{
-                      flexShrink: 0,
-                      ...(expanded && {
-                        mr: { xs: 0, md: 2 },
-                      }),
-                      ...(!expanded && {
-                        mr: 2,
-                      }),
-                      "&:hover": { textDecoration: "none !important" },
-                      backgroundColor: router.pathname.startsWith(Routes.BlogPage().pathname)
-                        ? "lightgray !important"
-                        : "transparent",
-                    }}
-                    color="inherit"
-                    onClick={collapseMobileMenu}
-                    className="w-full md:w-auto text-[#202020]"
-                  >
-                    Blog
-                  </Button>
-                </Link>
-                <TextField
-                  sx={{
-                    ...(expanded && {
                       mr: { xs: 0, md: 2 },
                       mb: { xs: 2, md: 0 },
                       order: { xs: -1, md: "unset" },
-                    }),
-                    ...(!expanded && {
-                      mr: 2,
-                      mb: 0,
-                    }),
-                  }}
-                  className="translate-x-0 translate-y-0 transform-gpu"
-                  // InputLabelProps={{ shrink: true, disableAnimation: true }}
-                  // variant="outlined"
-                  placeholder="Search..."
-                  onChange={(e) => setQuery(e.target.value)}
-                  onKeyPress={(e) => e.key === "Enter" && onSearchSubmit()}
-                  InputProps={{
-                    endAdornment: (
-                      <InputAdornment position="end">
-                        <Search />
-                      </InputAdornment>
-                    ),
-                  }}
-                />
-                <Link href={Routes.SettingsPage()} passHref={true} className="hover:!no-underline">
+                    }}
+                    className="translate-x-0 translate-y-0 transform-gpu"
+                    // InputLabelProps={{ shrink: true, disableAnimation: true }}
+                    // variant="outlined"
+                    placeholder="Search..."
+                    onChange={(e) => setQuery(e.target.value)}
+                    onKeyPress={(e) => e.key === "Enter" && onSearchSubmit()}
+                    InputProps={{
+                      endAdornment: (
+                        <InputAdornment position="end">
+                          <Search />
+                        </InputAdornment>
+                      ),
+                    }}
+                  />
+                  <Link
+                    href={Routes.SettingsPage()}
+                    passHref={true}
+                    className="hover:!no-underline"
+                  >
+                    <Button
+                      sx={{
+                        mr: { xs: 0, md: 2 },
+                        // mobile-menu-only entry; the desktop nav has the account dropdown instead
+                        display: { xs: "flex", md: "none" },
+                        "&:hover": { textDecoration: "none !important" },
+                        backgroundColor:
+                          Routes.SettingsPage().pathname === router.pathname
+                            ? "lightgray !important"
+                            : "transparent",
+                      }}
+                      color="inherit"
+                      onClick={collapseMobileMenu}
+                      className="w-full md:w-auto text-[#202020]"
+                    >
+                      Settings
+                    </Button>
+                  </Link>
                   <Button
                     sx={{
-                      ...(expanded && {
-                        mr: { xs: 0, md: 2 },
-                        display: { xs: "flex", md: "none" },
-                      }),
-                      ...(!expanded && {
-                        display: "none",
-                      }),
-                      "&:hover": { textDecoration: "none !important" },
+                      mr: { xs: 0, md: 2 },
+                      mb: { xs: 1, sm: 2, md: 0 },
+                      // mobile-menu-only entry; the desktop nav has the account dropdown instead
+                      display: { xs: "flex", md: "none" },
+                    }}
+                    color="inherit"
+                    onClick={handleLogout}
+                  >
+                    <Logout />
+                    <Box sx={{ ml: ".5rem" }}>Sign out</Box>
+                  </Button>
+
+                  <Button
+                    aria-label="Account of current user"
+                    aria-controls="menu-appbar"
+                    aria-haspopup="true"
+                    onClick={handleMenu}
+                    color="inherit"
+                    endIcon={<ExpandMore />}
+                    sx={{
                       backgroundColor:
                         Routes.SettingsPage().pathname === router.pathname
                           ? "lightgray !important"
                           : "transparent",
-                    }}
-                    color="inherit"
-                    onClick={collapseMobileMenu}
-                    className="w-full md:w-auto text-[#202020]"
-                  >
-                    Settings
-                  </Button>
-                </Link>
-                <Button
-                  sx={{
-                    ...(expanded && {
-                      mr: { xs: 0, md: 2 },
-                      mb: { xs: 1, sm: 2, md: 0 },
-                      display: { xs: "flex", md: "none" },
-                    }),
-                    ...(!expanded && {
-                      display: "none",
-                    }),
-                  }}
-                  color="inherit"
-                  onClick={handleLogout}
-                >
-                  <Logout />
-                  <Box sx={{ ml: ".5rem" }}>Sign out</Box>
-                </Button>
-
-                <Button
-                  aria-label="Account of current user"
-                  aria-controls="menu-appbar"
-                  aria-haspopup="true"
-                  onClick={handleMenu}
-                  color="inherit"
-                  endIcon={<ExpandMore />}
-                  sx={{
-                    backgroundColor:
-                      Routes.SettingsPage().pathname === router.pathname
-                        ? "lightgray !important"
-                        : "transparent",
-                    ...(expanded && {
                       display: { xs: "none", md: "flex" },
-                    }),
-                    ...(!expanded && {
-                      display: "flex",
-                    }),
-                  }}
-                >
-                  <Box className="account-dropdown">{session.username}</Box>
-                </Button>
+                    }}
+                  >
+                    <Box className="account-dropdown">{session.username}</Box>
+                  </Button>
 
-                <Menu
-                  id="menu-appbar"
-                  anchorEl={anchorEl}
-                  keepMounted
-                  open={Boolean(anchorEl)}
-                  onClose={handleClose}
-                  disableScrollLock={true}
-                >
-                  <MenuItem
-                    onClick={() => {
-                      router.push(Routes.SettingsPage())
-                      handleClose()
-                    }}
+                  <Menu
+                    id="menu-appbar"
+                    anchorEl={anchorEl}
+                    keepMounted
+                    open={Boolean(anchorEl)}
+                    onClose={handleClose}
+                    disableScrollLock={true}
                   >
-                    <Settings />
-                    <Box sx={{ ml: ".5rem" }}>Settings</Box>
-                  </MenuItem>
-                  <MenuItem
-                    onClick={async () => {
-                      handleClose()
-                      await handleLogout()
-                    }}
-                  >
-                    <Logout />
-                    <Box sx={{ ml: ".5rem" }}>Sign out</Box>
-                  </MenuItem>
-                </Menu>
-              </Box>
+                    <MenuItem
+                      onClick={() => {
+                        router.push(Routes.SettingsPage())
+                        handleClose()
+                      }}
+                    >
+                      <Settings />
+                      <Box sx={{ ml: ".5rem" }}>Settings</Box>
+                    </MenuItem>
+                    <MenuItem
+                      onClick={async () => {
+                        handleClose()
+                        await handleLogout()
+                      }}
+                    >
+                      <Logout />
+                      <Box sx={{ ml: ".5rem" }}>Sign out</Box>
+                    </MenuItem>
+                  </Menu>
+                </Box>
+              </Collapse>
             </Toolbar>
           </AppBar>
         </ClickAwayListener>

--- a/src/dreams/components/DreamForm.tsx
+++ b/src/dreams/components/DreamForm.tsx
@@ -88,7 +88,7 @@ export function DreamForm<S extends z.ZodType<any, any>>(props: FormProps<S>) {
             />
 
             <Suspense fallback={<LoadingSpiral />}>
-              <SymbolsAutocomplete />
+              <SymbolsAutocomplete allowCreate />
             </Suspense>
           </Fragment>
         )}

--- a/src/dreams/components/SymbolsAutocomplete.tsx
+++ b/src/dreams/components/SymbolsAutocomplete.tsx
@@ -18,7 +18,9 @@ function label(options: Symbol[]): PartialSymbol[] {
   }))
 }
 
-export const SymbolsAutocomplete = () => {
+// allowCreate: only the dream create/edit form may offer the `Add "…"` instant-symbol
+// option; the search/stats filter panels pick from existing symbols only
+export const SymbolsAutocomplete = ({ allowCreate = false }: { allowCreate?: boolean }) => {
   const user = useCurrentUser()
   const { setValues: setDialogValue, toggleDialog, state } = useInstantDreamDialog()
   const [, setCb] = state
@@ -46,7 +48,7 @@ export const SymbolsAutocomplete = () => {
           value={field.value}
           id="tags-filled"
           options={label(symbols)}
-          freeSolo
+          freeSolo={allowCreate}
           autoHighlight
           handleHomeEndKeys
           loading={isLoading}
@@ -102,7 +104,7 @@ export const SymbolsAutocomplete = () => {
             const filtered = filter(options, params)
 
             const isExisting = options.some((option) => params.inputValue === option.name)
-            if (params.inputValue !== "" && !isExisting) {
+            if (allowCreate && params.inputValue !== "" && !isExisting) {
               // @ts-expect-error type mismatch
               filtered.push({ inputValue: params.inputValue, name: `Add "${params.inputValue}"` })
             }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -90,6 +90,11 @@ function RootErrorFallback({ error, resetErrorBoundary }: ErrorFallbackProps) {
     return (
       <Layout>
         <Container>
+          {/* error/login fallback states must never be indexed (the other branches
+              get this via CustomErrorContainer) */}
+          <Head>
+            <meta name="robots" content="noindex" />
+          </Head>
           <Grid container sx={{ mb: 2 }}>
             <Grid container item sm={12} justifyContent="center">
               <Alert severity="warning">Your session expired. Please log in</Alert>


### PR DESCRIPTION
## What & why

Three changes that shared a session:

### 1. Mobile navbar now animates like the filter panels
The mobile menu used to snap open/closed via `display` toggles. It now lives in the same MUI `<Collapse>` the search/stats filter panels use — same easing, same feel. Below `md` it wraps to its own Toolbar line; on `md+` the Toolbar stays `nowrap`, so the desktop header is **pixel-identical to before** (verified against a `git stash` baseline at 1000/1280/1440px — an earlier draft regressed md–lg widths, caught and fixed during verification).

### 2. Symbol creation only from the dream form
`SymbolsAutocomplete` offered `Add "…"` everywhere it was mounted, including the search page filters and the stats advanced panel — creating a symbol from a *filter* makes no sense. New `allowCreate` prop (default off); only `DreamForm` passes it. Search/stats now show plain "No options" for unknown names, like the Symbols page jump box.

### 3. Fix Google indexing "499: Client Closed Request" as our snippet
Root cause chain (reproduced locally by intercepting `/api/` in puppeteer):
- `robots.txt` disallowed `/api/`, but even anonymous pages fire `POST /api/rpc/getCurrentUser` during hydration (Footer → `useCurrentUser`)
- Googlebot's renderer can't complete that fetch → the failed query throws to `RootErrorFallback`, which replaces the **whole SSR'd page** with the error sheep
- that render is HTTP 200 with no `noindex` → Google indexed it (`499: Client Closed Request` + the `error-sheep` / `dreamingsheep` image alts — exactly the snippet text)

Fixes: `robots.txt` no longer blocks `/api/` (RPC endpoints are POST-only, GET 404s — nothing to crawl), and every error state (`CustomErrorContainer` + the login fallback in `_app.tsx`) now emits `<meta name="robots" content="noindex">`.

**After merge + deploy**: Search Console → URL Inspection → Test Live URL (should render clean now) → Request Indexing.

## Verification (all against the running app, seeded `zhuangzi` user)

- Mobile 375px: Collapse height animates 0→471px over ~300ms; auto-collapses on navigation and click-away; reversing mid-animation works
- Desktop 1000/1280/1440px: header/title/nav positions byte-identical to `main` baseline
- Search filters + typed gibberish → "No options", no Add entry; dream form → `Add "…"` still offered
- Anonymous `/settings` (login fallback) and a forced RPC-500 on `/dreams` (error sheep) both render `meta robots=noindex`; homepage renders none
- `type:check`, `lint`, Prettier all clean

Also adds `.claude/skills/verify/SKILL.md` (agent-facing notes on driving this app with puppeteer) — happy to drop it if you'd rather keep the repo clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)