### PR TITLE
SEO: canonical links, complete social meta tags, homepage JSON-LD

### DIFF
--- a/src/core/layouts/Layout.tsx
+++ b/src/core/layouts/Layout.tsx
@@ -1,4 +1,5 @@
 import Head from "next/head"
+import { useRouter } from "next/router"
 import Footer from "src/core/layouts/Footer"
 import Header from "src/core/layouts/Header"
 import React, { Fragment, ReactNode, Suspense } from "react"
@@ -19,7 +20,11 @@ type LayoutProps = {
   childrenContainerClassName?: string
 }
 
-// const domain = 'https://dreamingsheep.net/' // TODO (future-feature): incorporate domain
+const DOMAIN = "https://dreamingsheep.net"
+const DESCRIPTION = "dreamingsheep, an online journal for your dreams and beyond"
+
+// social scrapers (Facebook, LinkedIn, WhatsApp, ...) silently drop relative og:image URLs
+const absoluteUrl = (path: string) => (path.startsWith("http") ? path : `${DOMAIN}${path}`)
 
 const Layout = ({
   title,
@@ -28,17 +33,25 @@ const Layout = ({
   children,
   childrenContainerClassName,
 }: LayoutProps) => {
-  // const ogImage = ogCoverImage ? `${domain}${ogCoverImage}` : `${domain}${ogCoverImageDefault.src}` // TODO (future-feature): incorporate domain
-  const ogImage = ogCoverImage ? ogCoverImage : ogCoverImageDefault.src
+  const router = useRouter()
+  const ogImage = absoluteUrl(ogCoverImage ? ogCoverImage : ogCoverImageDefault.src)
+  const pageTitle = title ? `${title} | dreamingsheep` : "dreamingsheep"
+  // bare domain + query-less path: one canonical per page, no ?utm_/?page= duplicates,
+  // and it reasserts the non-www preference on every page
+  const canonicalUrl = `${DOMAIN}${(router.asPath ?? "/").split("?")[0]?.split("#")[0]}`
 
   return (
     <Fragment>
       <Head>
-        <title>{`${title ? title + " | dreamingsheep" : "dreamingsheep"}`}</title>
-        <meta
-          name="description"
-          content="dreamingsheep, an online journal for your dreams and beyond"
-        />
+        <title>{pageTitle}</title>
+        <meta name="description" content={DESCRIPTION} />
+        <link rel="canonical" href={canonicalUrl} />
+        <meta property="og:site_name" content="dreamingsheep" />
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content={pageTitle} />
+        <meta property="og:description" content={DESCRIPTION} />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta name="twitter:card" content="summary_large_image" />
         <link rel="icon" href="/favicon.ico" />
         <link rel="icon" href={faviconApple.src} type="image/png" />
         {/* <link rel="icon" href={faviconSvg.src} type="image/svg+xml" />
@@ -56,8 +69,8 @@ const Layout = ({
         <meta property="og:image:height" content="630" />
         {ogCoverImageSecondary && (
           <>
-            <meta property="og:image" content={ogCoverImageSecondary} />
-            <meta property="twitter:image" content={ogCoverImageSecondary} />
+            <meta property="og:image" content={absoluteUrl(ogCoverImageSecondary)} />
+            <meta property="twitter:image" content={absoluteUrl(ogCoverImageSecondary)} />
           </>
         )}
         <noscript>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import { gSSP } from "src/blitz-server"
 import Link from "next/link"
+import Head from "next/head"
 import Image from "next/image"
 import { InferGetServerSidePropsType } from "next"
 import { useRouter } from "next/router"
@@ -17,6 +18,22 @@ import SheepGridContainer from "src/core/components/SheepGridContainer"
 import { Fragment, Suspense } from "react"
 import LoadingSpiral from "src/core/components/LoadingSpiral"
 
+// structured data for search engines — kept to plain facts, no review/rating fluff
+const JSON_LD = {
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  name: "dreamingsheep",
+  url: "https://dreamingsheep.net/",
+  description: "dreamingsheep, an online journal for your dreams and beyond",
+  applicationCategory: "LifestyleApplication",
+  operatingSystem: "Web",
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "USD",
+  },
+}
+
 const Home: BlitzPage<InferGetServerSidePropsType<typeof getServerSideProps>> = ({
   lastMonthDreamsCount,
   lastMonthLucidCount,
@@ -27,6 +44,12 @@ const Home: BlitzPage<InferGetServerSidePropsType<typeof getServerSideProps>> = 
 
   return (
     <Fragment>
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(JSON_LD) }}
+        />
+      </Head>
       <Container>
         <Suspense
           fallback={


### PR DESCRIPTION
## What & why

Follow-up to the Google-499 fix (#26) and the sitemap update — a sweep of the global `<head>` for minimal-but-real SEO wins. Everything lives in `Layout.tsx` (plus one JSON-LD block on the homepage); no page files change behavior.

- **Absolute `og:image`/`twitter:image` URLs** — they were relative (`/_next/static/media/…`), which Facebook/LinkedIn/WhatsApp scrapers silently drop. This was the old `TODO (future-feature): incorporate domain` comment, now done.
- **`<link rel="canonical">` on every page** — bare `https://dreamingsheep.net` + query-less path, so `?page=2`/`?utm_…` variants consolidate onto one URL and the non-www preference is asserted site-wide (the 301s already handle the host, this is belt-and-braces).
- **Complete OG/Twitter set** — `og:site_name`, `og:type`, `og:title`, `og:description`, `og:url`, `twitter:card=summary_large_image`. All derived from the existing `title`/`ogCoverImage` props, so per-page titles and cover images flow through unchanged.
- **Homepage JSON-LD** — a plain schema.org `WebApplication` (LifestyleApplication, price 0). Facts only, no rating/review fluff.

## Verified against the running app

- Homepage: canonical `https://dreamingsheep.net/`, full OG set, absolute image, valid JSON-LD in the SSR'd HTML
- FAQ: title `FAQ | dreamingsheep`, canonical/og:url `…/faq`, page-specific cover image
- `/blog?page=2` → canonical strips to `…/blog`
- Blog post with secondary OG image: both images absolute
- `type:check`, lint, Prettier clean

Not done (deliberately, to stay minimal): per-page meta descriptions (every page still shares the site-wide one — doing it properly means touching all 12 hardcoded blog TSX files, happy to do as a follow-up if wanted) and `BlogPosting` JSON-LD on articles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)