### PR TITLE
feat(symbols): list custom symbols only checkbox

### DIFF
--- a/src/pages/symbols/index.tsx
+++ b/src/pages/symbols/index.tsx
@@ -20,10 +20,17 @@ const SymbolsPage: BlitzPage = () => {
   const router = useRouter()
   const [createSymbolMutation, { isLoading: isCreateSymbolLoading }] = useMutation(createSymbol)
   const [showForm, setShowForm] = useState(false)
+  const [customOnly, setCustomOnly] = useState(false)
   const user = useCurrentUser()
 
   function goToLastPage() {
     router.push({ query: { refetch: "true" } })
+  }
+
+  function onCustomOnlyChange(checked: boolean) {
+    setCustomOnly(checked)
+    // the filter changes the page count — restart from page 1 (this also drops a stale ?id deep link)
+    router.push({ query: {} })
   }
 
   return (
@@ -62,8 +69,11 @@ const SymbolsPage: BlitzPage = () => {
           </Typography> */}
           <Suspense fallback={<LoadingSpiral />}>
             {/* quick jump — the list below is paginated, this finds a symbol directly */}
-            <SymbolJumpAutocomplete />
-            <SymbolsList />
+            <SymbolJumpAutocomplete
+              customOnly={customOnly}
+              onCustomOnlyChange={onCustomOnlyChange}
+            />
+            <SymbolsList customOnly={customOnly} />
           </Suspense>
           <p className="mt-6 text-right">
             <Button variant="contained" onClick={() => setShowForm(true)}>

--- a/src/symbols/components/SymbolJumpAutocomplete.tsx
+++ b/src/symbols/components/SymbolJumpAutocomplete.tsx
@@ -1,31 +1,54 @@
 import { useQuery } from "@blitzjs/rpc"
 import { useRouter } from "next/router"
 import { Routes } from "@blitzjs/next"
-import { Autocomplete, Box, Paper, TextField } from "@mui/material"
+import {
+  Autocomplete,
+  Box,
+  Checkbox,
+  FormControlLabel,
+  Paper,
+  TextField,
+  Typography,
+} from "@mui/material"
 import { Symbol } from "db"
 import React from "react"
 import { useCurrentUser } from "src/core/hooks/useCurrentUser"
 import getAutocompleteSymbols from "src/symbols/queries/getAutocompleteSymbols"
 
+interface SymbolJumpAutocompleteProps {
+  customOnly: boolean
+  onCustomOnlyChange: (checked: boolean) => void
+}
+
 // quick jump on the paginated Symbols page: picking a symbol navigates to
 // /symbols?id=<id>, which resolves its page and expands the card — the same
-// flow as following a symbol link from a dream
-export const SymbolJumpAutocomplete = () => {
+// flow as following a symbol link from a dream. The "custom symbols only"
+// checkbox hides the opted-in predefined/built-in symbols from the list below,
+// and from these options too — a jump target must exist in the filtered list,
+// or its page position could never resolve
+export const SymbolJumpAutocomplete = ({
+  customOnly,
+  onCustomOnlyChange,
+}: SymbolJumpAutocompleteProps) => {
   const user = useCurrentUser()
   const router = useRouter()
   const [{ symbols }, { isLoading }] = useQuery(
     getAutocompleteSymbols,
     {
       orderBy: { name: "asc" },
-      where: { OR: [{ relatedTo: { some: { id: user?.id } } }, { authorId: user?.id }] },
+      where: customOnly
+        ? { authorId: user?.id }
+        : { OR: [{ relatedTo: { some: { id: user?.id } } }, { authorId: user?.id }] },
       take: 200,
     },
-    { queryKey: ["get-symbols-autocomplete"] }
+    // the explicit key must include the filter, or toggling it would serve stale options
+    { queryKey: ["get-symbols-autocomplete", customOnly] }
   )
 
   return (
-    <Paper sx={{ mb: 7, p: 1 }}>
+    <Paper sx={{ mb: 7, p: 1, display: "flex", flexWrap: "wrap", alignItems: "center" }}>
       <Autocomplete
+        sx={{ flexGrow: 1, minWidth: "12rem" }}
         options={symbols as Symbol[]}
         autoHighlight
         handleHomeEndKeys
@@ -62,6 +85,17 @@ export const SymbolJumpAutocomplete = () => {
             InputProps={{ ...params.InputProps, disableUnderline: true }}
           />
         )}
+      />
+      <FormControlLabel
+        sx={{ mx: 0, whiteSpace: "nowrap" }}
+        control={
+          <Checkbox
+            size="small"
+            checked={customOnly}
+            onChange={(_, checked) => onCustomOnlyChange(checked)}
+          />
+        }
+        label={<Typography variant="body2">custom symbols only</Typography>}
       />
     </Paper>
   )

--- a/src/symbols/components/SymbolsList.tsx
+++ b/src/symbols/components/SymbolsList.tsx
@@ -7,7 +7,7 @@ import { Pagination, Paper, Box, Typography } from "@mui/material"
 import { ITEMS_PER_PAGE } from "src/core/constants/general"
 import LoadingSpiral from "src/core/components/LoadingSpiral"
 
-export const SymbolsList = () => {
+export const SymbolsList = ({ customOnly }: { customOnly: boolean }) => {
   const router = useRouter()
   const [editSymbolId, setEditSymbolId] = useState<number | null>(null)
   const page = Number(router.query.page) || 1
@@ -19,6 +19,7 @@ export const SymbolsList = () => {
       take: ITEMS_PER_PAGE,
       // deep link from a dream carries only the symbol id — ask the server which page it lives on
       positionOfId: !router.query.page && deepLinkedSymbolId ? deepLinkedSymbolId : undefined,
+      customOnly,
     }
   )
 

--- a/src/symbols/queries/getSymbolsWithUsage.ts
+++ b/src/symbols/queries/getSymbolsWithUsage.ts
@@ -16,22 +16,26 @@ export interface SymbolWithUsage extends Symbol {
   dreams: DreamMinimal[]
 }
 
-// visible symbols: built-ins the user opted into (relatedTo) + the user's own creations;
+// visible symbols: built-ins the user opted into (relatedTo) + the user's own creations,
+// or only the latter when customOnly is set (the "custom symbols only" checkbox);
 // occurrences only count the user's OWN dreams, which is why the ordering happens in SQL —
 // Prisma 3 can't `orderBy` a filtered relation count (see issue #12)
-const visibleSymbolsSql = (userId: number) => Prisma.sql`
+const visibleSymbolsSql = (userId: number, customOnly: boolean) => Prisma.sql`
   FROM "Symbol" s
   LEFT JOIN "_DreamToSymbol" ds ON ds."B" = s."id"
   LEFT JOIN "Dream" d ON d."id" = ds."A" AND d."userId" = ${userId}
   WHERE s."authorId" = ${userId}
-    OR EXISTS (SELECT 1 FROM "_SymbolToUser" su WHERE su."A" = s."id" AND su."B" = ${userId})
+    OR (${!customOnly} AND EXISTS (SELECT 1 FROM "_SymbolToUser" su WHERE su."A" = s."id" AND su."B" = ${userId}))
   GROUP BY s."id"
 `
 
 export default resolver.pipe(
   resolver.zod(GetSymbolsWithUsage),
   resolver.authorize(),
-  async ({ skip, take, positionOfId }: z.infer<typeof GetSymbolsWithUsage>, ctx: Ctx) => {
+  async (
+    { skip, take, positionOfId, customOnly }: z.infer<typeof GetSymbolsWithUsage>,
+    ctx: Ctx
+  ) => {
     const userId = ctx.session.userId!
 
     // count, page and (optional) deep-link position share the same predicate and are
@@ -39,12 +43,12 @@ export default resolver.pipe(
     const [countRows, page, ranked] = await Promise.all([
       db.$queryRaw<{ count: number }[]>`
         SELECT COUNT(*)::int AS "count"
-        FROM (SELECT s."id" ${visibleSymbolsSql(userId)}) visible
+        FROM (SELECT s."id" ${visibleSymbolsSql(userId, customOnly)}) visible
       `,
       // only the current page leaves the database, sorted by per-user usage
       db.$queryRaw<{ id: number; occurrences: number }[]>`
         SELECT s."id", COUNT(d."id")::int AS "occurrences"
-        ${visibleSymbolsSql(userId)}
+        ${visibleSymbolsSql(userId, customOnly)}
         ORDER BY "occurrences" DESC, s."id" ASC
         LIMIT ${take} OFFSET ${skip}
       `,
@@ -53,7 +57,7 @@ export default resolver.pipe(
         : db.$queryRaw<{ position: number }[]>`
             SELECT "position" FROM (
               SELECT s."id", (ROW_NUMBER() OVER (ORDER BY COUNT(d."id") DESC, s."id" ASC))::int AS "position"
-              ${visibleSymbolsSql(userId)}
+              ${visibleSymbolsSql(userId, customOnly)}
             ) ranked
             WHERE "id" = ${positionOfId}
           `,

--- a/src/symbols/validations.ts
+++ b/src/symbols/validations.ts
@@ -19,6 +19,8 @@ export const GetSymbolsWithUsage = z.object({
   // deep links from a dream only carry the symbol id — when set, the query also
   // returns that symbol's 1-based position so the client can jump to its page
   positionOfId: z.number().int().optional(),
+  // hide the opted-in predefined/built-in symbols, keeping only the user's own creations
+  customOnly: z.boolean().optional().default(false),
 })
 
 export const UpdateSymbol = z.object({


### PR DESCRIPTION
The "custom symbols only" checkbox is in, and everything around it is verified working end-to-end in a real browser.

What changed (4 files):

validations.ts:24 — GetSymbolsWithUsage gains customOnly (defaults to false, so the other caller, Settings' ExportDreams, is unaffected). getSymbolsWithUsage.ts:27 — the shared SQL predicate becomes authorId = user OR (NOT customOnly AND opted-into-built-in), so count, page, and deep-link position all honor the filter consistently. SymbolJumpAutocomplete.tsx — the Paper is now a flex row: search left, checkbox right (wraps below the search on mobile). The autocomplete options are filtered by the same flag — deliberately, because a jump navigates to /symbols?id=X and the server resolves that symbol's page within the filtered list; offering a hidden built-in would dead-end. I also had to extend the hardcoded queryKey with the flag, otherwise toggling served stale cached options. index.tsx — holds the customOnly state (not persisted, off by default) and resets pagination to page 1 on toggle, which also drops a stale ?id deep link. Verification (this was the bulk of the work, as you asked):

Type check, lint, and all 62 unit tests pass.
Puppeteer against a live dev server, logged in as zhuangzi: filter off → 12 cards, 2 pages; on → 6 own cards, 1 page; autocomplete shrinks from 9 matches to 3 own ones; jumping via autocomplete with the filter on resolves the right page and expands the card; toggling off restores the full list. Toggling while on page 2 correctly lands on page 1. A deep link to a built-in symbol (the from-a-dream flow, filter off) still resolves. Mobile (390px) has zero horizontal overflow. Existing e2e suites symbols (3 tests) and isolation (5 tests — important since I touched the visibility SQL) both pass.

## Description

Brief description of changes.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## How Has This Been Tested?

Describe the tests you ran.

## Screenshots (if applicable)

Before/after images for UI changes.

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
